### PR TITLE
Use LightGBM callbacks for early stopping

### DIFF
--- a/g2_hurdle/model/classifier.py
+++ b/g2_hurdle/model/classifier.py
@@ -3,8 +3,10 @@ from typing import Optional, Sequence
 import numpy as np
 
 try:
+    import lightgbm
     from lightgbm import LGBMClassifier
 except Exception as e:
+    lightgbm = None
     LGBMClassifier = None
 
 class HurdleClassifier:
@@ -19,7 +21,10 @@ class HurdleClassifier:
         fit_params = {}
         if X_val is not None and y_val is not None:
             fit_params["eval_set"] = [(X_val, (y_val > 0).astype(int))]
-            fit_params["early_stopping_rounds"] = early_stopping_rounds
+            if early_stopping_rounds > 0:
+                callbacks = fit_params.get("callbacks", [])
+                callbacks.append(lightgbm.early_stopping(early_stopping_rounds))
+                fit_params["callbacks"] = callbacks
         self.model.fit(X_train, y_train_bin, **fit_params)
 
     def predict_proba(self, X):

--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -3,8 +3,10 @@ from typing import Optional, Sequence
 import numpy as np
 
 try:
+    import lightgbm
     from lightgbm import LGBMRegressor
 except Exception as e:
+    lightgbm = None
     LGBMRegressor = None
 
 class HurdleRegressor:
@@ -22,7 +24,10 @@ class HurdleRegressor:
             mask_va = (y_val > 0)
             X_va, y_va = X_val[mask_va], y_val[mask_va]
             fit_params["eval_set"] = [(X_va, y_va)]
-            fit_params["early_stopping_rounds"] = early_stopping_rounds
+            if early_stopping_rounds > 0:
+                callbacks = fit_params.get("callbacks", [])
+                callbacks.append(lightgbm.early_stopping(early_stopping_rounds))
+                fit_params["callbacks"] = callbacks
         self.model.fit(X_tr, y_tr, **fit_params)
 
     def predict(self, X):


### PR DESCRIPTION
## Summary
- Switch hurdle classifier and regressor to use `lightgbm.early_stopping` callback
- Avoid deprecated `early_stopping_rounds` parameter in model fitting

## Testing
- `python -m g2_hurdle.cli train --train_csv /tmp/train_enc.csv --config /tmp/test_config.yaml` *(fails: LightGBMError: The number of features in data (20) is not the same as it was in training data (22))*

------
https://chatgpt.com/codex/tasks/task_e_68be4d2decc483289cc5773c999e6f76