### PR TITLE
Fix recursion pipeline docstring delimiters

### DIFF
--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -10,10 +10,10 @@ def _predict_one_step(df_future_row, clf, reg, threshold):
     return float(yhat[0]), float(p[0]), float(q[0])
 
 def recursive_forecast_grouped(context_df: pd.DataFrame, schema: dict, cfg: dict, clf, reg, threshold: float, horizon: int=7):
-    \"\"\"Run recursive forecast per series group (identified by schema['series']).
+    """Run recursive forecast per series group (identified by schema['series']).
     context_df: must contain at least the last 28 days per series.
     Returns DataFrame with columns: id, D1..Dh and optionally stacks of p,q for analysis.
-    \"\"\"
+    """
     date_col = schema["date"]
     target_col = schema["target"]
     series_cols = schema["series"]


### PR DESCRIPTION
## Summary
- Correct docstring delimiters in `recursive_forecast_grouped`

## Testing
- `python -m g2_hurdle.cli predict --test_dir data/test --sample_submission data/sample_submission.csv --out_path /tmp/out.csv` *(fails: AttributeError: 'Namespace' object has no attribute 'config')*


------
https://chatgpt.com/codex/tasks/task_e_68be4e81ba208328b3e3742d743c65ed