### PR TITLE
fix: point train script to correct dataset

### DIFF
--- a/scripts/run_train.sh
+++ b/scripts/run_train.sh
@@ -1,4 +1,4 @@
 
 python -m g2_hurdle.cli train \
-  --train_csv data/test.csv \
+  --train_csv data/train.csv \
   --config g2_hurdle/configs/base.yaml


### PR DESCRIPTION
## Summary
- use `data/train.csv` in training script

## Testing
- `bash -x scripts/run_train.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be50c27f8883288a539fc353f78389