### PR TITLE
Add Korean config and update training script

### DIFF
--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -1,0 +1,58 @@
+
+runtime:
+  seed: 42
+  n_jobs: -1
+  use_gpu: true
+
+io:
+  artifacts_dir: "./artifacts"
+  cache_features: true
+
+data:
+  date_col_candidates: ["영업일자"]
+  target_col_candidates: ["매출수량"]
+  id_col_candidates: ["영업장명_메뉴명"]
+  min_context_days: 28
+
+features:
+  fourier: { weekly_K: 3, yearly_K: 10 }
+  lags: [1,2,7,14,28,365]
+  rollings: [7,14,28]
+  use_holidays: false
+  intermittency: { enable: true }
+
+model:
+  classifier:
+    num_leaves: 63
+    learning_rate: 0.05
+    n_estimators: 2000
+    subsample: 0.8
+    colsample_bytree: 0.8
+    reg_alpha: 1.0
+    reg_lambda: 1.0
+    device_type: gpu
+  regressor:
+    objective: "tweedie"
+    tweedie_variance_power: 1.2
+    num_leaves: 127
+    learning_rate: 0.03
+    n_estimators: 4000
+    subsample: 0.8
+    colsample_bytree: 0.8
+    min_data_in_leaf: 50
+    device_type: gpu
+  calibration:
+    enable: false
+    method: "isotonic"
+
+cv:
+  horizon: 7
+  init_train_ratio: 0.7
+  early_stopping_rounds: 100
+  n_folds_min: 2
+  time_series_split: "rolling_origin"
+
+threshold:
+  grid_start: 0.01
+  grid_end: 0.99
+  grid_step: 0.01

--- a/scripts/run_train.sh
+++ b/scripts/run_train.sh
@@ -1,4 +1,4 @@
 
 python -m g2_hurdle.cli train \
   --train_csv data/train.csv \
-  --config g2_hurdle/configs/base.yaml
+  --config g2_hurdle/configs/korean.yaml


### PR DESCRIPTION
## Summary
- add Korean-specific configuration with localized column names
- run training script using the new Korean configuration

## Testing
- `bash scripts/run_train.sh` *(fails: ValueError: could not convert string to float: '느티나무 셀프BBQ_1인 수저세트')*

------
https://chatgpt.com/codex/tasks/task_e_68be536d29108328a3b4d2c05e8a24c4