### PR TITLE
feat: allow direct schema columns in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ python -m g2_hurdle.cli predict \
   --out_path outputs/submission.csv
 ```
 All imports are relative; drop this folder as project root and run the commands.
+
+## Data configuration
+
+Columns used by the toolkit can be provided directly in the `data` section of the
+YAML config:
+
+```yaml
+data:
+  date_col: ds
+  target_col: y
+  id_cols: [series_id]
+```
+
+If these keys are omitted, `resolve_schema` falls back to the corresponding
+`*_col_candidates` lists to infer column names.

--- a/g2_hurdle/data/schema.py
+++ b/g2_hurdle/data/schema.py
@@ -1,6 +1,7 @@
 
 from typing import Dict, List
 
+
 def resolve_schema(df_columns: List[str], cfg: dict) -> Dict[str, object]:
     cols = set(df_columns)
     data_cfg = cfg.get("data", {})
@@ -11,17 +12,31 @@ def resolve_schema(df_columns: List[str], cfg: dict) -> Dict[str, object]:
                 return c
         return None
 
-    date_col = pick_first(data_cfg.get("date_col_candidates", []))
-    target_col = pick_first(data_cfg.get("target_col_candidates", []))
-    id_candidates = data_cfg.get("id_col_candidates", [])
-    series_cols = [c for c in id_candidates if c in cols]
+    # Prefer direct keys if provided; fall back to candidate lists
+    date_col = data_cfg.get("date_col")
+    if date_col not in cols:
+        date_col = pick_first(data_cfg.get("date_col_candidates", []))
+
+    target_col = data_cfg.get("target_col")
+    if target_col not in cols:
+        target_col = pick_first(data_cfg.get("target_col_candidates", []))
+
+    if "id_cols" in data_cfg:
+        series_cols = [c for c in data_cfg.get("id_cols", []) if c in cols]
+    else:
+        id_candidates = data_cfg.get("id_col_candidates", [])
+        series_cols = [c for c in id_candidates if c in cols]
 
     missing = []
     if date_col is None:
-        missing.append("date column from candidates")
+        missing.append("date column (date_col or date_col_candidates)")
     if target_col is None:
-        missing.append("target column from candidates")
+        missing.append("target column (target_col or target_col_candidates)")
     if missing:
-        raise ValueError(f"Schema resolution failed. Missing: {missing}. Available columns: {sorted(list(cols))}")
+        raise ValueError(
+            "Schema resolution failed. Missing: {}. Available columns: {}".format(
+                missing, sorted(list(cols))
+            )
+        )
 
     return {"date": date_col, "target": target_col, "series": series_cols}


### PR DESCRIPTION
## Summary
- support direct `date_col`, `target_col`, and `id_cols` config keys before falling back to candidate lists
- document data schema configuration in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5498634883288f1f321d01b3388c