### PR TITLE
Add dependency installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ python -m g2_hurdle.cli predict \
 ```
 All imports are relative; drop this folder as project root and run the commands.
 
+## Dependencies
+
+Run `python dependency.py` to install dependencies.
+
+
 ## Data configuration
 
 Columns used by the toolkit can be provided directly in the `data` section of the

--- a/dependency.py
+++ b/dependency.py
@@ -1,0 +1,13 @@
+import pkgutil
+import subprocess
+import sys
+
+REQUIRED_PACKAGES = ["numpy", "pandas", "lightgbm"]
+
+def install_missing_packages(packages):
+    for pkg in packages:
+        if pkgutil.find_loader(pkg) is None:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+if __name__ == "__main__":
+    install_missing_packages(REQUIRED_PACKAGES)


### PR DESCRIPTION
## Summary
- add a `dependency.py` helper to ensure numpy, pandas, and lightgbm are installed
- document dependency installation in the README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be5535e9288328b400ab838fe1fbf4