### PR TITLE
docs: update data paths in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 ## Quick Start
 ```bash
 python -m g2_hurdle.cli train \
-  --train_csv data/test.csv \
+  --train_csv data/train.csv \
   --config g2_hurdle/configs/base.yaml
 
 python -m g2_hurdle.cli predict \
   --test_dir data/test \
-  --sample_submission sample_submission.csv \
+  --sample_submission data/sample_submission.csv \
   --out_path outputs/submission.csv
 ```
 All imports are relative; drop this folder as project root and run the commands.


### PR DESCRIPTION
## Summary
- fix training command to use data/train.csv
- update sample submission path to data/sample_submission.csv

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be55d25b448328b044eae78d668f46