### PR TITLE
Add YAML and scikit-learn dependencies

### DIFF
--- a/dependency.py
+++ b/dependency.py
@@ -2,7 +2,13 @@ import pkgutil
 import subprocess
 import sys
 
-REQUIRED_PACKAGES = ["numpy", "pandas", "lightgbm"]
+REQUIRED_PACKAGES = [
+    "numpy",
+    "pandas",
+    "lightgbm",
+    "pyyaml",  # for reading YAML configuration files
+    "scikit-learn",  # optional utilities for model evaluation
+]
 
 def install_missing_packages(packages):
     for pkg in packages:


### PR DESCRIPTION
## Summary
- include pyyaml and scikit-learn in dependency installer with clarifying comments

## Testing
- `python -m py_compile dependency.py`


------
https://chatgpt.com/codex/tasks/task_e_68be56ed69cc832895ec1dd169d9f499