### PR TITLE
Add top-level training script

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,0 +1,13 @@
+import yaml
+from g2_hurdle.pipeline.train import run_train
+
+
+def main():
+    with open("g2_hurdle/configs/korean.yaml", "r") as f:
+        cfg = yaml.safe_load(f)
+    cfg["paths"] = {"train_csv": "data/train.csv"}
+    run_train(cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add executable `train.py` that loads Korean config, injects train CSV path, and runs training pipeline

## Testing
- `python -m py_compile train.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be599e17cc8328819d820bff7a2fb4