### PR TITLE
Add standalone prediction script

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,18 @@
+import os
+import yaml
+from g2_hurdle.pipeline.predict import run_predict
+
+def main():
+    with open("g2_hurdle/configs/korean.yaml", "r") as f:
+        cfg = yaml.safe_load(f)
+    cfg["paths"] = {
+        "test_dir": "data/test",
+        "sample_submission": "data/sample_submission.csv",
+        "out_path": "outputs/submission.csv",
+        "artifacts_dir": "./artifacts",
+    }
+    os.makedirs("outputs", exist_ok=True)
+    run_predict(cfg)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add top-level `predict.py` script to run model inference with default paths
- Ensure output directory exists before executing prediction pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be5a514eb883288247c46dbfa2d584