### PR TITLE
Silence groupby deprecation warnings

### DIFF
--- a/g2_hurdle/fe/intermittency.py
+++ b/g2_hurdle/fe/intermittency.py
@@ -31,7 +31,7 @@ def create_intermittency_features(df: pd.DataFrame, target_col: str, series_cols
         return group
 
     if series_cols:
-        out = out.groupby(series_cols, group_keys=False).apply(_apply)
+        out = out.groupby(series_cols, group_keys=False, observed=False).apply(_apply)
     else:
         out = _apply(out)
     return out

--- a/g2_hurdle/fe/lags_rolling.py
+++ b/g2_hurdle/fe/lags_rolling.py
@@ -8,7 +8,7 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
     rolls = cfg.get("features", {}).get("rollings", [7,14,28])
 
     if series_cols:
-        g = out.groupby(series_cols, group_keys=False)
+        g = out.groupby(series_cols, group_keys=False, observed=False)
     else:
         # treat whole df as one group
         g = [(None, out)]
@@ -34,7 +34,7 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
         return group
 
     if series_cols:
-        out = out.groupby(series_cols, group_keys=False).apply(_apply)
+        out = out.groupby(series_cols, group_keys=False, observed=False).apply(_apply)
     else:
         out = _apply(out)
 


### PR DESCRIPTION
## Summary
- specify `observed=False` for all pandas `groupby` usages in lag/rolling and intermittency feature helpers

## Testing
- `python - <<'PY'
import pandas as pd, warnings
from g2_hurdle.fe.lags_rolling import create_lags_and_rolling_features
from g2_hurdle.fe.intermittency import create_intermittency_features

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    df = pd.read_csv('data/train.csv')
    df['영업일자']=pd.to_datetime(df['영업일자'])
    df=df.sort_values(['영업장명_메뉴명','영업일자'])
    cfg={'features': {'lags':[1,2], 'rollings':[7]}}
    create_lags_and_rolling_features(df,'매출수량',['영업장명_메뉴명'],cfg)
    create_intermittency_features(df,'매출수량',['영업장명_메뉴명'])
    obs_warnings=[str(m.message) for m in w if 'observed' in str(m.message)]
    print('observed warnings:', len(obs_warnings))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be60ed6ba88328a00118f41e230329