### PR TITLE
Handle categorical DataFrames in training

### DIFF
--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -1,6 +1,7 @@
 
 from typing import Optional, Sequence
 import numpy as np
+import pandas as pd
 
 try:
     import lightgbm
@@ -18,11 +19,20 @@ class HurdleRegressor:
 
     def fit(self, X_train, y_train, X_val=None, y_val=None, early_stopping_rounds=100):
         mask_tr = (y_train > 0)
-        X_tr, y_tr = X_train[mask_tr], y_train[mask_tr]
+        if isinstance(X_train, pd.DataFrame):
+            X_tr = X_train.loc[mask_tr]
+        else:
+            X_tr = X_train[mask_tr]
+        y_tr = y_train[mask_tr]
+
         fit_params = {}
         if X_val is not None and y_val is not None:
             mask_va = (y_val > 0)
-            X_va, y_va = X_val[mask_va], y_val[mask_va]
+            if isinstance(X_val, pd.DataFrame):
+                X_va = X_val.loc[mask_va]
+            else:
+                X_va = X_val[mask_va]
+            y_va = y_val[mask_va]
             fit_params["eval_set"] = [(X_va, y_va)]
             if early_stopping_rounds > 0:
                 callbacks = fit_params.get("callbacks", [])

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -4,6 +4,9 @@ import numpy as np
 from ..fe import run_feature_engineering
 
 def _predict_one_step(df_future_row, clf, reg, threshold):
+    obj_cols = df_future_row.select_dtypes(include="object").columns
+    for c in obj_cols:
+        df_future_row[c] = df_future_row[c].astype("category")
     p = clf.predict_proba(df_future_row)
     q = reg.predict(df_future_row)
     yhat = (p > threshold).astype(float) * np.maximum(0.0, q)

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -45,7 +45,7 @@ def run_train(cfg: dict):
             X = fe_subset.drop(columns=[c for c in drop_cols if c in fe_subset.columns], errors="ignore").copy()
             obj_cols = X.select_dtypes(include="object").columns
             for c in obj_cols:
-                X[c] = X[c].astype("category").cat.codes
+                X[c] = X[c].astype("category")
             return X
 
         X_all = _prepare_X(fe)
@@ -68,10 +68,10 @@ def run_train(cfg: dict):
             fe_tr = fe.loc[tr_inner.index]
             fe_va = fe.loc[va_inner.index] if va_inner is not None else None
 
-            X_tr = _prepare_X(fe_tr).values
+            X_tr = _prepare_X(fe_tr)
             y_tr = tr_inner[target_col].values
             if va_inner is not None:
-                X_val = _prepare_X(fe_va).values
+                X_val = _prepare_X(fe_va)
                 y_val = va_inner[target_col].values
             else:
                 X_val, y_val = None, None
@@ -129,7 +129,7 @@ def run_train(cfg: dict):
 
     # Retrain on full data
     with Timer("Final fit on full data"):
-        X = X_all.values
+        X = X_all
         y = y_all
         cls_params = dict(cfg.get("model", {}).get("classifier", {}))
         reg_params = dict(cfg.get("model", {}).get("regressor", {}))


### PR DESCRIPTION
## Summary
- Preserve pandas DataFrames for training and final fit
- Allow LightGBM to receive categorical dtypes by casting object columns to category
- Update regressor and recursion to work with DataFrames

## Testing
- `python -m py_compile g2_hurdle/pipeline/train.py g2_hurdle/model/regressor.py g2_hurdle/pipeline/recursion.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be6445c97c8328b6d80293c34dc03b