### PR TITLE
Ensure inference feature alignment with training metadata

### DIFF
--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -4,6 +4,7 @@ from .calendar import create_calendar_features
 from .fourier import create_fourier_features
 from .lags_rolling import create_lags_and_rolling_features
 from .intermittency import create_intermittency_features
+from .preprocess import prepare_features
 
 def run_feature_engineering(df: pd.DataFrame, cfg: dict, schema: dict) -> pd.DataFrame:
     date_col = schema["date"]

--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+
+def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categorical_cols=None):
+    X = fe_df.drop(columns=[c for c in drop_cols if c in fe_df.columns], errors="ignore").copy()
+    X = X.replace([np.inf, -np.inf], np.nan)
+    obj_cols = X.select_dtypes(include="object").columns
+    for c in obj_cols:
+        X[c] = X[c].astype("category")
+    X = X.fillna(0)
+    if feature_cols is None:
+        bad = [c for c in X.columns if X[c].isna().all() or X[c].nunique(dropna=True) <= 1]
+        X = X.drop(columns=bad)
+        feature_cols = X.columns.tolist()
+        categorical_cols = X.select_dtypes(include="category").columns.tolist()
+    else:
+        missing = [c for c in feature_cols if c not in X.columns]
+        for c in missing:
+            X[c] = 0
+        extra = [c for c in X.columns if c not in feature_cols]
+        if extra:
+            X = X.drop(columns=extra)
+        X = X[feature_cols]
+        for c in categorical_cols or []:
+            if c in X.columns:
+                X[c] = X[c].astype("category")
+    return X, feature_cols, categorical_cols


### PR DESCRIPTION
## Summary
- Move `prepare_features` into new `fe/preprocess.py` and expose via `g2_hurdle.fe`
- Use `prepare_features` across training, recursion, and prediction pipelines to align feature columns
- Load feature and categorical column lists from artifacts and pass them into recursive forecasting and prediction

## Testing
- `python -m py_compile g2_hurdle/fe/preprocess.py g2_hurdle/fe/__init__.py g2_hurdle/pipeline/train.py g2_hurdle/pipeline/recursion.py g2_hurdle/pipeline/predict.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be6bd513c08328b01adbb8cb523511