### PR TITLE
refactor: drop deprecated device param

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ By default, both scripts load the configuration from `g2_hurdle/configs/korean.y
 `predict.py` consumes the artifacts, expects test files in `data/test` with a
 `data/sample_submission.csv`, and writes predictions to `outputs/submission.csv`.
 
+## GPU configuration
+
+To enable GPU acceleration, set `runtime.use_gpu` to `true` in the YAML
+configuration. The pipeline will automatically set `device_type: gpu` for the
+LightGBM models. The older `device` parameter is deprecated and should not be
+used.
+
 ## Dependencies
 
 Run `python dependency.py` to install dependencies.

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -74,8 +74,8 @@ def run_train(cfg: dict):
             cls_params = dict(cfg.get("model", {}).get("classifier", {}))
             reg_params = dict(cfg.get("model", {}).get("regressor", {}))
             if cfg.get("runtime", {}).get("use_gpu", False):
-                cls_params.setdefault("device_type", "gpu"); cls_params.setdefault("device", "gpu")
-                reg_params.setdefault("device_type", "gpu"); reg_params.setdefault("device", "gpu")
+                cls_params.setdefault("device_type", "gpu")
+                reg_params.setdefault("device_type", "gpu")
             clf = HurdleClassifier(cls_params, categorical_feature=cat_tr)
             reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
 
@@ -146,8 +146,8 @@ def run_train(cfg: dict):
         cls_params = dict(cfg.get("model", {}).get("classifier", {}))
         reg_params = dict(cfg.get("model", {}).get("regressor", {}))
         if cfg.get("runtime", {}).get("use_gpu", False):
-            cls_params.setdefault("device_type", "gpu"); cls_params.setdefault("device", "gpu")
-            reg_params.setdefault("device_type", "gpu"); reg_params.setdefault("device", "gpu")
+            cls_params.setdefault("device_type", "gpu")
+            reg_params.setdefault("device_type", "gpu")
         clf_final = HurdleClassifier(cls_params, categorical_feature=categorical_cols)
         reg_final = HurdleRegressor(reg_params, categorical_feature=categorical_cols)
         clf_final.fit(X, y, None, None, early_stopping_rounds=0)


### PR DESCRIPTION
## Summary
- remove `device="gpu"` assignments in training pipeline
- document GPU configuration without deprecated `device` flag

## Testing
- `python -m py_compile g2_hurdle/pipeline/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6d03afbc8328a2835370bf8f87ff