### PR TITLE
Handle NaNs before categorical conversion in feature prep

### DIFF
--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -5,10 +5,12 @@ import pandas as pd
 def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categorical_cols=None):
     X = fe_df.drop(columns=[c for c in drop_cols if c in fe_df.columns], errors="ignore").copy()
     X = X.replace([np.inf, -np.inf], np.nan)
+    # Fill missing values before converting strings to categorical to avoid
+    # introducing new categories during `fillna` on categorical columns.
+    X = X.fillna(0)
     obj_cols = X.select_dtypes(include="object").columns
     for c in obj_cols:
         X[c] = X[c].astype("category")
-    X = X.fillna(0)
     if feature_cols is None:
         bad = [c for c in X.columns if X[c].isna().all() or X[c].nunique(dropna=True) <= 1]
         X = X.drop(columns=bad)


### PR DESCRIPTION
## Summary
- fill missing values before converting object columns to categorical to avoid introducing new categories
- document missing-value handling during preprocessing

## Testing
- `python -m py_compile g2_hurdle/fe/preprocess.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be74814ff483288f4ca38d599331c7