### PR TITLE
Align feature configuration for prediction

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -28,6 +28,9 @@ def run_predict(cfg: dict):
         features_meta = art.get("features.json", {})
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
+        train_cfg = art.get("config.json", {})
+        if "features" in train_cfg:
+            cfg["features"] = train_cfg["features"]
 
     H = int(cfg.get("cv", {}).get("horizon", 7))
 


### PR DESCRIPTION
## Summary
- ensure prediction reuses the feature-generation configuration saved during training

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be77960cfc8328a8ccc6c01d50988d