### PR TITLE
Handle scarce positive samples during CV

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -13,6 +13,7 @@ data:
   target_col_candidates: ["sales","y","target"]
   id_col_candidates: ["store_id","menu_id","series_id","영업장명","메뉴명"]
   min_context_days: 28
+  min_positive_ratio: 0.01
 
 features:
   fourier: { weekly_K: 3, yearly_K: 10 }
@@ -51,6 +52,7 @@ cv:
   early_stopping_rounds: 100
   n_folds_min: 2
   time_series_split: "rolling_origin"
+  min_positive_samples: 10
 
 threshold:
   grid_start: 0.01

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -13,6 +13,7 @@ data:
   target_col_candidates: ["매출수량"]
   id_col_candidates: ["영업장명_메뉴명"]
   min_context_days: 28
+  min_positive_ratio: 0.01
 
 features:
   fourier: { weekly_K: 3, yearly_K: 10 }
@@ -51,6 +52,7 @@ cv:
   early_stopping_rounds: 100
   n_folds_min: 2
   time_series_split: "rolling_origin"
+  min_positive_samples: 10
 
 threshold:
   grid_start: 0.01

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -7,6 +7,7 @@ from ..utils.logging import get_logger
 from ..utils.timer import Timer
 from ..utils.io import load_data, save_artifacts
 from ..utils.keys import build_series_id
+from ..utils.preprocessing import ensure_min_positive_ratio
 from ..fe import run_feature_engineering, prepare_features
 from ..cv.tscv import rolling_forecast_origin_split
 from ..model.classifier import HurdleClassifier
@@ -14,6 +15,19 @@ from ..model.regressor import HurdleRegressor
 from ..model.threshold import find_optimal_threshold
 
 logger = get_logger("Train")
+
+
+class ZeroPredictor:
+    """Simple model that always predicts zeros."""
+
+    def fit(self, *args, **kwargs):
+        return self
+
+    def predict(self, X):
+        return np.zeros(len(X))
+
+    def predict_proba(self, X):
+        return np.zeros(len(X))
 
 def _split_train_valid_by_tail_dates(df, date_col, ratio_tail=28):
     # validation is the last `ratio_tail` unique dates of training range
@@ -32,7 +46,18 @@ def run_train(cfg: dict):
 
     with Timer("Load data"):
         df, schema = load_data(train_csv, cfg)
-        date_col = schema["date"]; target_col = schema["target"]; series_cols = schema["series"]
+        date_col = schema["date"]
+        target_col = schema["target"]
+        series_cols = schema["series"]
+        min_pos_ratio = float(cfg.get("data", {}).get("min_positive_ratio", 0.0))
+        if min_pos_ratio > 0:
+            df = ensure_min_positive_ratio(
+                df,
+                target_col,
+                min_pos_ratio,
+                seed=int(cfg.get("runtime", {}).get("seed", 42)),
+            )
+            df = df.sort_values([*series_cols, date_col]).reset_index(drop=True)
         df["id"] = build_series_id(df, series_cols)
 
     with Timer("Feature engineering"):
@@ -64,46 +89,60 @@ def run_train(cfg: dict):
             else:
                 X_val, y_val = None, None
 
-            drop_cols_tr = [c for c in X_tr.columns if X_tr[c].nunique(dropna=True) <= 1]
-            if drop_cols_tr:
-                X_tr = X_tr.drop(columns=drop_cols_tr)
+            min_pos_samples = int(cfg.get("cv", {}).get("min_positive_samples", 0))
+            pos_count = int((y_tr > 0).sum())
+            skip_fold = pos_count < min_pos_samples
+            if skip_fold:
+                logger.warning(
+                    f"Fold (train_end={tr_end.date()}): only {pos_count} positive samples < {min_pos_samples}; skipping training.")
+
+            preds_df = None
+            if not skip_fold:
+                drop_cols_tr = [c for c in X_tr.columns if X_tr[c].nunique(dropna=True) <= 1]
+                if drop_cols_tr:
+                    X_tr = X_tr.drop(columns=drop_cols_tr)
+                    if X_val is not None:
+                        X_val = X_val.drop(columns=drop_cols_tr, errors="ignore")
+                feature_cols_tr = [c for c in feature_cols if c not in drop_cols_tr]
+                categorical_cols_tr = [c for c in categorical_cols if c not in drop_cols_tr]
+                X_tr = X_tr[feature_cols_tr]
                 if X_val is not None:
-                    X_val = X_val.drop(columns=drop_cols_tr, errors="ignore")
-            feature_cols_tr = [c for c in feature_cols if c not in drop_cols_tr]
-            categorical_cols_tr = [c for c in categorical_cols if c not in drop_cols_tr]
-            X_tr = X_tr[feature_cols_tr]
-            if X_val is not None:
-                X_val = X_val[feature_cols_tr]
+                    X_val = X_val[feature_cols_tr]
 
-            cat_tr = [c for c in categorical_cols_tr if c in X_tr.columns]
-            cls_params = dict(cfg.get("model", {}).get("classifier", {}))
-            reg_params = dict(cfg.get("model", {}).get("regressor", {}))
-            if cfg.get("runtime", {}).get("use_gpu", False):
-                cls_params.setdefault("device_type", "gpu")
-                reg_params.setdefault("device_type", "gpu")
-            clf = HurdleClassifier(cls_params, categorical_feature=cat_tr)
-            reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
+                cat_tr = [c for c in categorical_cols_tr if c in X_tr.columns]
+                cls_params = dict(cfg.get("model", {}).get("classifier", {}))
+                reg_params = dict(cfg.get("model", {}).get("regressor", {}))
+                if cfg.get("runtime", {}).get("use_gpu", False):
+                    cls_params.setdefault("device_type", "gpu")
+                    reg_params.setdefault("device_type", "gpu")
+                clf = HurdleClassifier(cls_params, categorical_feature=cat_tr)
+                reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
 
-            with Timer(f"Fit fold (train_end={tr_end.date()}) - classifier"):
-                clf.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
-            with Timer(f"Fit fold (train_end={tr_end.date()}) - regressor"):
-                reg.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
+                with Timer(f"Fit fold (train_end={tr_end.date()}) - classifier"):
+                    clf.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
+                with Timer(f"Fit fold (train_end={tr_end.date()}) - regressor"):
+                    reg.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
 
-            # Recursive simulate on validation horizon per id
-            from .recursion import recursive_forecast_grouped
-            # Use context: all rows up to tr_end per series
-            context = df[df[date_col] <= tr_end].copy()
-            preds_df = recursive_forecast_grouped(
-                context,
-                schema,
-                cfg,
-                clf,
-                reg,
-                threshold=0.5,
-                horizon=H,
-                feature_cols=feature_cols_tr,
-                categorical_cols=categorical_cols_tr,
-            )
+                # Recursive simulate on validation horizon per id
+                from .recursion import recursive_forecast_grouped
+                # Use context: all rows up to tr_end per series
+                context = df[df[date_col] <= tr_end].copy()
+                preds_df = recursive_forecast_grouped(
+                    context,
+                    schema,
+                    cfg,
+                    clf,
+                    reg,
+                    threshold=0.5,
+                    horizon=H,
+                    feature_cols=feature_cols_tr,
+                    categorical_cols=categorical_cols_tr,
+                )
+            else:
+                ids = df_va["id"].unique()
+                preds_df = pd.DataFrame({"id": ids})
+                for i in range(1, H + 1):
+                    preds_df[f"D{i}"] = 0.0
             # For threshold tuning we need y_true for validation horizon
             # Construct ground truth for va period in wide form
             va_truth = df_va.copy()
@@ -120,13 +159,17 @@ def run_train(cfg: dict):
             truth_df = pd.DataFrame(truth_rows)
 
             merged = preds_df.merge(truth_df, on="id", how="inner", suffixes=("_pred","_true"))
-            for i in range(1, H+1):
+            for i in range(1, H + 1):
                 yp = merged[f"D{i}_pred"].values
                 yt = merged[f"D{i}_true"].values
-                # For tuning, we approximate p and q by using yp as reg outcome and assume proba ~1 if yp>0 else 0.3
-                # (Simplification: exact p,q not returned from recursion; keeping interface lean.)
-                p_all.extend((yp>0).astype(float)*0.7 + 0.3*(yp<=0))
-                q_all.extend(yp)
+                if skip_fold:
+                    p_all.extend(np.zeros_like(yt))
+                    q_all.extend(np.zeros_like(yt))
+                else:
+                    # For tuning, we approximate p and q by using yp as reg outcome and assume proba ~1 if yp>0 else 0.3
+                    # (Simplification: exact p,q not returned from recursion; keeping interface lean.)
+                    p_all.extend((yp > 0).astype(float) * 0.7 + 0.3 * (yp <= 0))
+                    q_all.extend(yp)
                 y_true_all.extend(yt)
 
     with Timer("Threshold search"):
@@ -153,10 +196,18 @@ def run_train(cfg: dict):
         if cfg.get("runtime", {}).get("use_gpu", False):
             cls_params.setdefault("device_type", "gpu")
             reg_params.setdefault("device_type", "gpu")
-        clf_final = HurdleClassifier(cls_params, categorical_feature=categorical_cols)
-        reg_final = HurdleRegressor(reg_params, categorical_feature=categorical_cols)
-        clf_final.fit(X, y, None, None, early_stopping_rounds=0)
-        reg_final.fit(X, y, None, None, early_stopping_rounds=0)
+        min_pos_samples = int(cfg.get("cv", {}).get("min_positive_samples", 0))
+        pos_count_full = int((y > 0).sum())
+        if pos_count_full < min_pos_samples:
+            logger.warning(
+                f"Full data has only {pos_count_full} positive samples < {min_pos_samples}; using ZeroPredictor.")
+            clf_final = ZeroPredictor()
+            reg_final = ZeroPredictor()
+        else:
+            clf_final = HurdleClassifier(cls_params, categorical_feature=categorical_cols)
+            reg_final = HurdleRegressor(reg_params, categorical_feature=categorical_cols)
+            clf_final.fit(X, y, None, None, early_stopping_rounds=0)
+            reg_final.fit(X, y, None, None, early_stopping_rounds=0)
 
     artifacts = {
         "classifier.pkl": clf_final,

--- a/g2_hurdle/utils/preprocessing.py
+++ b/g2_hurdle/utils/preprocessing.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+
+
+def ensure_min_positive_ratio(df: pd.DataFrame, target_col: str, min_ratio: float, seed: int = 42) -> pd.DataFrame:
+    """Ensure that the fraction of rows with positive target values is at least `min_ratio`.
+
+    If the current positive ratio is below the desired threshold, positive rows
+    are resampled with replacement until the ratio is satisfied.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing the target column.
+    target_col : str
+        Name of the target column.
+    min_ratio : float
+        Minimum required ratio of positive target samples (0-1 range).
+    seed : int, optional
+        Random seed for sampling, by default 42.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe augmented with additional positive samples if needed.
+    """
+    if min_ratio <= 0:
+        return df
+
+    total = len(df)
+    if total == 0:
+        return df
+
+    pos_mask = df[target_col] > 0
+    pos_count = int(pos_mask.sum())
+    if pos_count == 0:
+        return df
+
+    current_ratio = pos_count / total
+    if current_ratio >= min_ratio:
+        return df
+
+    required_pos = int(np.ceil(min_ratio * total))
+    additional = required_pos - pos_count
+    pos_df = df.loc[pos_mask]
+    extra = pos_df.sample(n=additional, replace=True, random_state=seed)
+    df_aug = pd.concat([df, extra], ignore_index=True)
+    return df_aug


### PR DESCRIPTION
## Summary
- Add preprocessing helper to oversample positive rows when their ratio is too small
- Skip model training on folds lacking enough positive targets and emit zero predictions
- Guard final fit with the same check, falling back to zero predictors

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be784db9608328a763fb41700b4125