### PR TITLE
feat: encode calendar features

### DIFF
--- a/g2_hurdle/fe/calendar.py
+++ b/g2_hurdle/fe/calendar.py
@@ -2,15 +2,33 @@
 import pandas as pd
 import numpy as np
 
+
 def create_calendar_features(df: pd.DataFrame, date_col: str) -> pd.DataFrame:
+    """Generate basic calendar features.
+
+    In addition to integer date parts, cyclical representations are added and the
+    original discrete components are cast to ``category`` so downstream callers
+    can treat them as such (e.g. for LightGBM's categorical_feature).
+    """
+
     out = df.copy()
     d = out[date_col]
+
+    # raw components
     out["dow"] = d.dt.weekday
     out["week"] = d.dt.isocalendar().week.astype(int)
     out["month"] = d.dt.month
     out["quarter"] = d.dt.quarter
     out["year"] = d.dt.year
+
+    # cyclical (sin/cos) encodings
+    for col, period in [("dow", 7), ("week", 52), ("month", 12), ("quarter", 4)]:
+        val = out[col].astype(float)
+        out[f"{col}_sin"] = np.sin(2 * np.pi * val / period)
+        out[f"{col}_cos"] = np.cos(2 * np.pi * val / period)
+        out[col] = out[col].astype("category")
+
     out["is_month_start"] = d.dt.is_month_start.astype(int)
     out["is_month_end"] = d.dt.is_month_end.astype(int)
-    out["is_weekend"] = d.dt.weekday.isin([5,6]).astype(int)
+    out["is_weekend"] = d.dt.weekday.isin([5, 6]).astype(int)
     return out

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -28,6 +28,8 @@ def run_predict(cfg: dict):
         features_meta = art.get("features.json", {})
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
+        base_cats = ["dow", "week", "month", "quarter"]
+        categorical_cols = sorted(set(categorical_cols).union(base_cats))
         train_cfg = art.get("config.json", {})
         if "features" in train_cfg:
             cfg["features"] = train_cfg["features"]

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -64,6 +64,9 @@ def run_train(cfg: dict):
         fe = run_feature_engineering(df, cfg, schema)
         drop_cols = [date_col, target_col] + series_cols + ["id"]
         X_all, feature_cols, categorical_cols = prepare_features(fe, drop_cols)
+        # ensure calendar components are treated as categorical features
+        base_cats = [c for c in ["dow", "week", "month", "quarter"] if c in X_all.columns]
+        categorical_cols = sorted(set(categorical_cols).union(base_cats))
         y_all = df[target_col].values
 
     H = int(cfg.get("cv", {}).get("horizon", 7))


### PR DESCRIPTION
## Summary
- encode day/week/month/quarter with sin/cos cycles and categorical dtype
- ensure calendar parts are treated as categorical features during training and prediction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be7a35536483289a60dde4b3a59f88