### PR TITLE
Handle NA values in lag and intermittency features

### DIFF
--- a/g2_hurdle/fe/intermittency.py
+++ b/g2_hurdle/fe/intermittency.py
@@ -18,16 +18,20 @@ def create_intermittency_features(df: pd.DataFrame, target_col: str, series_cols
                 last = i
                 dsls.append(0)
             else:
-                dsls.append((i - last) if last is not None else np.nan)
+                dsls.append((i - last) if last is not None else 0)
         group["days_since_last_sale"] = dsls
 
         # rolling zero count 7d
         zero_flag = (y==0).astype(int)
-        group["rolling_zero_count_7d"] = zero_flag.shift(1).rolling(window=7).sum()
+        group["rolling_zero_count_7d"] = zero_flag.shift(1).rolling(window=7, min_periods=1).sum()
 
         # average interdemand interval (rolling mean of dsls)
         dsls_series = group["days_since_last_sale"]
-        group["avg_interdemand_interval"] = dsls_series.shift(1).rolling(window=28, min_periods=3).mean()
+        group["avg_interdemand_interval"] = dsls_series.shift(1).rolling(window=28, min_periods=1).mean()
+        for c in group.select_dtypes(include="category").columns:
+            if 0 not in group[c].cat.categories:
+                group[c] = group[c].cat.add_categories([0])
+        group.fillna(0, inplace=True)
         return group
 
     if series_cols:

--- a/g2_hurdle/fe/lags_rolling.py
+++ b/g2_hurdle/fe/lags_rolling.py
@@ -26,11 +26,15 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
             group[f"lag_{lag}"] = s.shift(lag)
         s_shift = s.shift(1)  # leakage guard
         for w in rolls:
-            r = s_shift.rolling(window=w)
+            r = s_shift.rolling(window=w, min_periods=1)
             group[f"roll_mean_{w}"] = r.mean()
             group[f"roll_std_{w}"] = r.std()
             group[f"roll_min_{w}"] = r.min()
             group[f"roll_max_{w}"] = r.max()
+        for c in group.select_dtypes(include="category").columns:
+            if 0 not in group[c].cat.categories:
+                group[c] = group[c].cat.add_categories([0])
+        group.fillna(0, inplace=True)
         return group
 
     if series_cols:


### PR DESCRIPTION
## Summary
- Ensure rolling statistics use `min_periods=1` and fill missing values with zeros in lag features
- Add zero defaults in intermittency features and fill groups to avoid NaNs

## Testing
- `python - <<'PY'
import yaml
from g2_hurdle.utils.io import load_data
from g2_hurdle.fe import run_feature_engineering
with open('g2_hurdle/configs/korean.yaml', 'r', encoding='utf-8') as f:
    cfg = yaml.safe_load(f)
df, schema = load_data('data/train.csv', cfg)
fe = run_feature_engineering(df, cfg, schema)
print('Total NaNs after feature engineering:', int(fe.isna().sum().sum()))
PY`
- `python - <<'PY'
import yaml
from g2_hurdle.pipeline.train import run_train
with open('g2_hurdle/configs/korean.yaml', 'r', encoding='utf-8') as f:
    cfg = yaml.safe_load(f)
cfg['runtime']['use_gpu'] = False
cfg['model']['classifier']['device_type'] = 'cpu'
cfg['model']['regressor']['device_type'] = 'cpu'
cfg['paths']={'train_csv':'data/train.csv'}
run_train(cfg)
PY` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68be99c98fcc8328949a8bbb993c6cc7