### PR TITLE
Handle low positive sample counts in regressor

### DIFF
--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -2,6 +2,8 @@
 from typing import Optional, Sequence
 import numpy as np
 
+from ..utils.logging import get_logger
+
 try:
     import lightgbm
     from lightgbm import LGBMRegressor
@@ -9,8 +11,22 @@ except Exception as e:
     lightgbm = None
     LGBMRegressor = None
 
+
+logger = get_logger("Regressor")
+
+
+class ZeroPredictor:
+    """Simple model that always predicts zeros."""
+
+    def fit(self, *args, **kwargs):
+        return self
+
+    def predict(self, X):
+        return np.zeros(len(X))
+
+
 class HurdleRegressor:
-    def __init__(self, model_params: dict, categorical_feature: Optional[Sequence[str]]=None):
+    def __init__(self, model_params: dict, categorical_feature: Optional[Sequence[str]] = None):
         if LGBMRegressor is None:
             raise ImportError("lightgbm not installed. Please install lightgbm.")
         self.model = LGBMRegressor(**model_params)
@@ -18,6 +34,17 @@ class HurdleRegressor:
 
     def fit(self, X_train, y_train, X_val=None, y_val=None, early_stopping_rounds=100):
         mask_tr = (y_train > 0)
+        pos_count = int(mask_tr.sum())
+        min_leaf = int(self.model.get_params().get("min_data_in_leaf", 20))
+        if pos_count < min_leaf:
+            if pos_count == 0:
+                logger.warning("No positive samples; using ZeroPredictor for regressor.")
+                self.model = ZeroPredictor()
+                return self
+            logger.warning(
+                f"min_data_in_leaf={min_leaf} exceeds positive samples={pos_count}; reducing to {pos_count}."
+            )
+            self.model.set_params(min_data_in_leaf=pos_count)
         X_tr, y_tr = X_train[mask_tr], y_train[mask_tr]
         fit_params = {
             "categorical_feature": self.categorical_feature,


### PR DESCRIPTION
## Summary
- log and handle low positive counts for LightGBM regressor
- reduce `min_data_in_leaf` or switch to `ZeroPredictor` when positives are insufficient

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bede505cc4832893da86f0e0b183fc