### PR TITLE
Handle single-class folds in training

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -53,6 +53,7 @@ cv:
   n_folds_min: 2
   time_series_split: "rolling_origin"
   min_positive_samples: 10
+  min_negative_samples: 10
 
 threshold:
   grid_start: 0.01

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -53,6 +53,7 @@ cv:
   n_folds_min: 2
   time_series_split: "rolling_origin"
   min_positive_samples: 10
+  min_negative_samples: 10
 
 threshold:
   grid_start: 0.01


### PR DESCRIPTION
## Summary
- Skip CV folds with only one class and warn
- Apply same single-class check on final training and fall back to ZeroPredictor
- Add configurable `min_negative_samples` option

## Testing
- `pytest -q`
- `python -m py_compile g2_hurdle/pipeline/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68bee146e27883289336efe1d09ebff9