### PR TITLE
Disable groupby sorting to preserve row order

### DIFF
--- a/g2_hurdle/fe/intermittency.py
+++ b/g2_hurdle/fe/intermittency.py
@@ -35,7 +35,10 @@ def create_intermittency_features(df: pd.DataFrame, target_col: str, series_cols
         return group
 
     if series_cols:
-        out = out.groupby(series_cols, group_keys=False, observed=False).apply(_apply)
+        out = out.groupby(
+            series_cols, group_keys=False, observed=False, sort=False
+        ).apply(_apply)
+        out = out.sort_index()
     else:
         out = _apply(out)
     return out

--- a/g2_hurdle/fe/lags_rolling.py
+++ b/g2_hurdle/fe/lags_rolling.py
@@ -8,7 +8,7 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
     rolls = cfg.get("features", {}).get("rollings", [7,14,28])
 
     if series_cols:
-        g = out.groupby(series_cols, group_keys=False, observed=False)
+        g = out.groupby(series_cols, group_keys=False, observed=False, sort=False)
     else:
         # treat whole df as one group
         g = [(None, out)]
@@ -38,7 +38,10 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
         return group
 
     if series_cols:
-        out = out.groupby(series_cols, group_keys=False, observed=False).apply(_apply)
+        out = out.groupby(
+            series_cols, group_keys=False, observed=False, sort=False
+        ).apply(_apply)
+        out = out.sort_index()
     else:
         out = _apply(out)
 


### PR DESCRIPTION
## Summary
- prevent automatic sorting in feature engineering groupby operations by setting `sort=False`
- restore original index order after groupby apply

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee97d5ec08328884349c6e2dd0f63