### PR TITLE
Expose regressor feature names and align recursive forecasting

### DIFF
--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -46,6 +46,8 @@ class HurdleRegressor:
             if pos_count == 0:
                 logger.warning("No positive samples; using ZeroPredictor for regressor.")
                 self.model = ZeroPredictor()
+                if hasattr(X_train, "columns"):
+                    self.feature_names_ = list(X_train.columns)
                 return self
             logger.warning(
                 f"min_data_in_leaf={min_leaf} exceeds positive samples={pos_count}; reducing to {pos_count}."
@@ -66,7 +68,7 @@ class HurdleRegressor:
                 if len(drop_va_cols) > 0:
                     X_va = X_va.drop(columns=drop_va_cols)
             if hasattr(X_tr, "columns") and hasattr(X_va, "columns"):
-                common = X_tr.columns.intersection(X_va.columns)
+                common = X_tr.columns.intersection(X_va.columns, sort=False)
                 X_tr = X_tr[common]
                 X_va = X_va[common]
             fit_params = {
@@ -86,6 +88,8 @@ class HurdleRegressor:
             if hasattr(X_tr, "columns"):
                 fit_params["feature_name"] = list(X_tr.columns)
         self.model.fit(X_tr, y_tr, **fit_params)
+        if hasattr(X_tr, "columns"):
+            self.feature_names_ = list(X_tr.columns)
 
     def predict(self, X):
         return self.model.predict(X)

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -150,7 +150,7 @@ def run_train(cfg: dict):
                         reg,
                         threshold=0.5,
                         horizon=H,
-                        feature_cols=feature_cols_tr,
+                        feature_cols=reg.feature_names_,
                         categorical_cols=categorical_cols_tr,
                     )
             if skip_fold:


### PR DESCRIPTION
## Summary
- Preserve column order when aligning training and validation sets in `HurdleRegressor`
- Store regressor's `feature_names_` after fitting for external access
- Use `reg.feature_names_` during recursive forecasting to keep training/prediction columns consistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68beeb616d3c8328a75bea691d975e08