### PR TITLE
Align features between models and enforce prediction shape checks

### DIFF
--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -2,10 +2,21 @@
 import pandas as pd
 import numpy as np
 from ..fe import run_feature_engineering, prepare_features
+from ..utils.logging import get_logger
 
-def _predict_one_step(df_future_row, clf, reg, threshold):
-    p = clf.predict_proba(df_future_row)
-    q = reg.predict(df_future_row)
+logger = get_logger("Recursion")
+
+
+def _predict_one_step(X, clf, reg, threshold):
+    if X.shape[1] != len(getattr(reg, "feature_names_", [])):
+        logger.fatal(
+            "Feature shape mismatch: X has %d columns while regressor expects %d",
+            X.shape[1],
+            len(getattr(reg, "feature_names_", [])),
+        )
+    assert X.shape[1] == len(getattr(reg, "feature_names_", [])), "Regressor feature mismatch"
+    p = clf.predict_proba(X)
+    q = reg.predict(X)
     yhat = (p > threshold).astype(float) * np.maximum(0.0, q)
     return float(yhat[0]), float(p[0]), float(q[0])
 


### PR DESCRIPTION
## Summary
- Capture classifier and regressor feature names immediately after fitting
- Use shared feature set between models for recursive forecasting with warning when they differ
- Validate input shape during recursive predictions and log fatal on mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68beef89705c83288f5e278c2d013b40