### PR TITLE
Use callback-based early stopping

### DIFF
--- a/lgbm_sanity_check.py
+++ b/lgbm_sanity_check.py
@@ -156,7 +156,7 @@ def train_lgbm(args, X, y, trn_idx, val_idx):
         valid_sets=[dtrain, dvalid],
         valid_names=["train","valid"],
         num_boost_round=5000,
-        early_stopping_rounds=200,
+        callbacks=[lgb.early_stopping(200)],
         keep_training_booster=True,
     )
     return model


### PR DESCRIPTION
## Summary
- replace legacy `early_stopping_rounds` with callback-based API in `lgbm_sanity_check.py`

## Testing
- `python lgbm_sanity_check.py --csv data/train.csv --nrows 1000`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef39c4b2c8328a6968561728cc191