### PR TITLE
Align classifier with regressor features

### DIFF
--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -8,13 +8,22 @@ logger = get_logger("Recursion")
 
 
 def _predict_one_step(X, clf, reg, threshold):
-    if X.shape[1] != len(getattr(reg, "feature_names_", [])):
+    reg_feats = len(getattr(reg, "feature_names_", []))
+    clf_feats = len(getattr(clf, "feature_names_", []))
+    if clf_feats != reg_feats:
         logger.fatal(
-            "Feature shape mismatch: X has %d columns while regressor expects %d",
-            X.shape[1],
-            len(getattr(reg, "feature_names_", [])),
+            "Feature count mismatch: classifier expects %d vs regressor %d",
+            clf_feats,
+            reg_feats,
         )
-    assert X.shape[1] == len(getattr(reg, "feature_names_", [])), "Regressor feature mismatch"
+    assert clf_feats == reg_feats, "Classifier/regressor feature count mismatch"
+    if X.shape[1] != reg_feats:
+        logger.fatal(
+            "Feature shape mismatch: X has %d columns while models expect %d",
+            X.shape[1],
+            reg_feats,
+        )
+    assert X.shape[1] == reg_feats, "Regressor feature mismatch"
     p = clf.predict_proba(X)
     q = reg.predict(X)
     yhat = (p > threshold).astype(float) * np.maximum(0.0, q)


### PR DESCRIPTION
## Summary
- Train regressor before classifier during CV folds and refit the classifier using the regressor's feature set.
- Pass the regressor's feature list to recursive forecasting to ensure consistent inputs.
- Enforce identical feature counts between classifier and regressor during recursive prediction.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef5bb88c48328b4ca3b30e9339921