### PR TITLE
Replace min_data_in_leaf with min_child_samples

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -31,6 +31,7 @@ model:
     colsample_bytree: 0.8
     reg_alpha: 1.0
     reg_lambda: 1.0
+    verbose: -1
     device_type: gpu
   regressor:
     objective: "tweedie"
@@ -40,7 +41,8 @@ model:
     n_estimators: 4000
     subsample: 0.8
     colsample_bytree: 0.8
-    min_data_in_leaf: 50
+    min_child_samples: 50
+    verbose: -1
     device_type: gpu
   calibration:
     enable: false

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -31,6 +31,7 @@ model:
     colsample_bytree: 0.8
     reg_alpha: 1.0
     reg_lambda: 1.0
+    verbose: -1
     device_type: gpu
   regressor:
     objective: "tweedie"
@@ -40,7 +41,8 @@ model:
     n_estimators: 4000
     subsample: 0.8
     colsample_bytree: 0.8
-    min_data_in_leaf: 50
+    min_child_samples: 50
+    verbose: -1
     device_type: gpu
   calibration:
     enable: false

--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -41,7 +41,7 @@ class HurdleRegressor:
         """
         mask_tr = (y_train > 0)
         pos_count = int(mask_tr.sum())
-        min_leaf = int(self.model.get_params().get("min_data_in_leaf", 20))
+        min_leaf = int(self.model.get_params().get("min_child_samples", 20))
         if pos_count < min_leaf:
             if pos_count == 0:
                 logger.warning("No positive samples; using ZeroPredictor for regressor.")
@@ -50,9 +50,9 @@ class HurdleRegressor:
                     self.feature_names_ = list(X_train.columns)
                 return self
             logger.warning(
-                f"min_data_in_leaf={min_leaf} exceeds positive samples={pos_count}; reducing to {pos_count}."
+                f"min_child_samples={min_leaf} exceeds positive samples={pos_count}; reducing to {pos_count}."
             )
-            self.model.set_params(min_data_in_leaf=pos_count)
+            self.model.set_params(min_child_samples=pos_count)
         X_tr, y_tr = X_train[mask_tr], y_train[mask_tr]
         if hasattr(X_tr, "nunique"):
             tr_counts = X_tr.nunique()

--- a/lgbm_sanity_check.py
+++ b/lgbm_sanity_check.py
@@ -22,7 +22,7 @@ def parse_args():
     ap.add_argument("--target_col", type=str, default="매출수량")
     ap.add_argument("--nrows", type=int, default=None, help="디버깅을 위해 일부만 읽고 싶다면 지정")
     ap.add_argument("--valid_days", type=int, default=28, help="검증 기간(일)")
-    ap.add_argument("--min_data_in_leaf", type=int, default=30)
+    ap.add_argument("--min_child_samples", type=int, default=30)
     ap.add_argument("--min_sum_hessian_in_leaf", type=float, default=1e-3)
     ap.add_argument("--max_bin", type=int, default=1023)
     ap.add_argument("--seed", type=int, default=42)
@@ -134,7 +134,7 @@ def train_lgbm(args, X, y, trn_idx, val_idx):
         n_estimators=3000,
         num_leaves=127,
         max_bin=args.max_bin,
-        min_data_in_leaf=args.min_data_in_leaf,
+        min_child_samples=args.min_child_samples,
         min_sum_hessian_in_leaf=args.min_sum_hessian_in_leaf,
         feature_pre_filter=False,
         min_data_in_bin=1,
@@ -142,7 +142,7 @@ def train_lgbm(args, X, y, trn_idx, val_idx):
         bagging_freq=1,
         feature_fraction=0.9,
         seed=args.seed,
-        verbose=1,
+        verbose=-1,
         zero_as_missing=False,
         force_col_wise=True,   # 안전
     )


### PR DESCRIPTION
## Summary
- replace deprecated min_data_in_leaf parameter with min_child_samples in configs and regressor
- update lgbm_sanity_check script and suppress LightGBM output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68befc5d406083288a466fb384db0f3a