### PR TITLE
Precompute static features for recursive forecasting

### DIFF
--- a/g2_hurdle/fe/static.py
+++ b/g2_hurdle/fe/static.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+from .calendar import create_calendar_features
+from .fourier import create_fourier_features
+
+
+def prepare_static_future_features(df: pd.DataFrame, schema: dict, cfg: dict, horizon: int) -> pd.DataFrame:
+    """Pre-compute calendar and Fourier features for all future dates.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Historical data containing at least the date column.
+    schema : dict
+        Schema specifying column names. Must include ``date``.
+    cfg : dict
+        Configuration used for Fourier feature generation.
+    horizon : int
+        Number of days ahead to generate features for.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame indexed by future dates with calendar and Fourier features
+        for each required horizon step.
+    """
+    date_col = schema["date"]
+    last_date = df[date_col].max()
+    future_dates = pd.date_range(last_date + pd.Timedelta(days=1), periods=horizon, freq="D")
+    future_df = pd.DataFrame({date_col: future_dates})
+    out = create_calendar_features(future_df, date_col)
+    out = create_fourier_features(out, date_col, cfg)
+    out = out.set_index(date_col)
+    return out


### PR DESCRIPTION
## Summary
- add `prepare_static_future_features` to build calendar and Fourier features for future horizons
- refactor recursion pipeline to precompute static features and only recompute dynamic lags and intermittency during forecasting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beffd1cab8832882daf0f65b8b66b9