### PR TITLE
Add dynamic lag/rolling updates with intermittency support

### DIFF
--- a/g2_hurdle/fe/lags_rolling.py
+++ b/g2_hurdle/fe/lags_rolling.py
@@ -46,3 +46,77 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
         out = _apply(out)
 
     return out
+
+
+def update_lags_and_rollings(ctx_tail: pd.DataFrame, new_y: float, cfg: dict) -> pd.DataFrame:
+    """Update lag and rolling statistics for the next step.
+
+    Parameters
+    ----------
+    ctx_tail : pd.DataFrame
+        DataFrame containing only the most recent rows required to compute
+        lag/rolling features. The last row should correspond to the latest
+        known observation.
+    new_y : float
+        Newly observed (or predicted) target value to append to the history.
+    cfg : dict
+        Configuration dictionary containing ``features.lags`` and
+        ``features.rollings`` entries.
+
+    Returns
+    -------
+    pd.DataFrame
+        Updated tail dataframe whose last row holds the features for the
+        next horizon step.
+    """
+
+    ctx = ctx_tail.copy()
+    lags = cfg.get("features", {}).get("lags", [1, 2, 7, 14, 28, 365])
+    rolls = cfg.get("features", {}).get("rollings", [7, 14, 28])
+
+    # infer target column: numeric column that is not a lag/rolling feature
+    num_cols = ctx.select_dtypes(include="number").columns
+    target_candidates = [
+        c for c in num_cols if not c.startswith("lag_") and not c.startswith("roll_")
+    ]
+    if not target_candidates:
+        raise ValueError("Could not infer target column for lag/rolling update")
+    target_col = target_candidates[0]
+
+    # set the newest observation on the last row
+    ctx.loc[ctx.index[-1], target_col] = new_y
+
+    # base new row on the last row to keep static columns
+    new_row = ctx.tail(1).copy()
+
+    # compute lag features for the next step
+    for lag in lags:
+        if lag == 1:
+            new_row[f"lag_{lag}"] = new_y
+        else:
+            prev_col = f"lag_{lag-1}"
+            if prev_col in ctx.columns:
+                new_row[f"lag_{lag}"] = ctx.iloc[-1][prev_col]
+            else:
+                new_row[f"lag_{lag}"] = ctx[target_col].iloc[-lag]
+
+    # compute rolling statistics using the updated target history
+    y_series = ctx[target_col]
+    for w in rolls:
+        hist = y_series.tail(w)
+        new_row[f"roll_mean_{w}"] = hist.mean()
+        new_row[f"roll_std_{w}"] = hist.std()
+        new_row[f"roll_min_{w}"] = hist.min()
+        new_row[f"roll_max_{w}"] = hist.max()
+
+    # future target is unknown
+    new_row[target_col] = np.nan
+
+    # append and keep only the necessary tail
+    ctx = pd.concat([ctx, new_row], ignore_index=True)
+    max_lag = max(lags) if lags else 1
+    max_roll = max(rolls) if rolls else 1
+    tail_len = max(max_lag, max_roll) + 1
+    ctx = ctx.tail(tail_len).reset_index(drop=True)
+    ctx.fillna(0, inplace=True)
+    return ctx


### PR DESCRIPTION
## Summary
- Add `update_lags_and_rollings` to compute next-step lag and rolling features from context tail
- Add `update_intermittency_features` for incremental intermittency feature updates
- Refactor recursive forecasting to keep only tail context and update features incrementally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf0143c1f483289fc01d4157349c3b