### PR TITLE
Add GPU defaults and memory guidance

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -24,26 +24,30 @@ features:
 
 model:
   classifier:
-    num_leaves: 63
+    num_leaves: 63  # Reduce if GPU memory is insufficient
     learning_rate: 0.05
     n_estimators: 2000
     subsample: 0.8
-    colsample_bytree: 0.8
+    feature_fraction: 0.8
     reg_alpha: 1.0
     reg_lambda: 1.0
     verbose: -1
     device_type: gpu
+    gpu_use_dp: false
+    max_bin: 255  # Reduce if GPU memory is insufficient
   regressor:
     objective: "tweedie"
     tweedie_variance_power: 1.2
-    num_leaves: 127
+    num_leaves: 127  # Reduce if GPU memory is insufficient
     learning_rate: 0.03
     n_estimators: 4000
     subsample: 0.8
-    colsample_bytree: 0.8
+    feature_fraction: 0.8
     min_child_samples: 50
     verbose: -1
     device_type: gpu
+    gpu_use_dp: false
+    max_bin: 255  # Reduce if GPU memory is insufficient
   calibration:
     enable: false
     method: "isotonic"

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -24,26 +24,30 @@ features:
 
 model:
   classifier:
-    num_leaves: 63
+    num_leaves: 63  # Reduce if GPU memory is insufficient
     learning_rate: 0.05
     n_estimators: 2000
     subsample: 0.8
-    colsample_bytree: 0.8
+    feature_fraction: 0.8
     reg_alpha: 1.0
     reg_lambda: 1.0
     verbose: -1
     device_type: gpu
+    gpu_use_dp: false
+    max_bin: 255  # Reduce if GPU memory is insufficient
   regressor:
     objective: "tweedie"
     tweedie_variance_power: 1.2
-    num_leaves: 127
+    num_leaves: 127  # Reduce if GPU memory is insufficient
     learning_rate: 0.03
     n_estimators: 4000
     subsample: 0.8
-    colsample_bytree: 0.8
+    feature_fraction: 0.8
     min_child_samples: 50
     verbose: -1
     device_type: gpu
+    gpu_use_dp: false
+    max_bin: 255  # Reduce if GPU memory is insufficient
   calibration:
     enable: false
     method: "isotonic"

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -128,8 +128,15 @@ def run_train(cfg: dict):
                     cls_params = dict(cfg.get("model", {}).get("classifier", {}))
                     reg_params = dict(cfg.get("model", {}).get("regressor", {}))
                     if cfg.get("runtime", {}).get("use_gpu", False):
+                        # Ensure GPU-specific defaults are present; adjust max_bin or num_leaves if OOM occurs
                         cls_params.setdefault("device_type", "gpu")
                         reg_params.setdefault("device_type", "gpu")
+                        cls_params.setdefault("gpu_use_dp", False)
+                        reg_params.setdefault("gpu_use_dp", False)
+                        cls_params.setdefault("max_bin", 255)
+                        reg_params.setdefault("max_bin", 255)
+                        cls_params.setdefault("feature_fraction", 0.8)
+                        reg_params.setdefault("feature_fraction", 0.8)
                     reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
 
                     # Fit regressor first
@@ -227,8 +234,15 @@ def run_train(cfg: dict):
             cls_params = dict(cfg.get("model", {}).get("classifier", {}))
             reg_params = dict(cfg.get("model", {}).get("regressor", {}))
             if cfg.get("runtime", {}).get("use_gpu", False):
+                # Ensure GPU defaults are applied; lower max_bin or num_leaves if memory is tight
                 cls_params.setdefault("device_type", "gpu")
                 reg_params.setdefault("device_type", "gpu")
+                cls_params.setdefault("gpu_use_dp", False)
+                reg_params.setdefault("gpu_use_dp", False)
+                cls_params.setdefault("max_bin", 255)
+                reg_params.setdefault("max_bin", 255)
+                cls_params.setdefault("feature_fraction", 0.8)
+                reg_params.setdefault("feature_fraction", 0.8)
             min_pos_samples = int(cfg.get("cv", {}).get("min_positive_samples", 0))
             min_neg_samples = int(cfg.get("cv", {}).get("min_negative_samples", 0))
             y_bin_full = (y > 0)


### PR DESCRIPTION
## Summary
- default GPU-related parameters added to base and Korean configs
- ensure new parameters are preserved during training parameter merging
- add comments about reducing `max_bin` or `num_leaves` if GPU memory is insufficient

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf67b2541483289d562a35215a436d