### PR TITLE
Handle categorical features after dropping constant columns

### DIFF
--- a/g2_hurdle/model/classifier.py
+++ b/g2_hurdle/model/classifier.py
@@ -23,9 +23,7 @@ class HurdleClassifier:
         if len(unique_classes) < 2:
             raise ValueError("Training data contains only one class.")
 
-        fit_params = {
-            "categorical_feature": self.categorical_feature,
-        }
+        fit_params = {}
         if hasattr(X_train, "columns"):
             fit_params["feature_name"] = list(X_train.columns)
 
@@ -55,6 +53,12 @@ class HurdleClassifier:
 
         if n_features == 0:
             raise ValueError("No informative features after constant-column removal.")
+
+        if isinstance(self.categorical_feature, list) and hasattr(X_train, "columns"):
+            cats = [c for c in self.categorical_feature if c in X_train.columns]
+        else:
+            cats = self.categorical_feature
+        fit_params["categorical_feature"] = cats
 
         if X_val is not None and y_val is not None:
             y_val_bin = (y_val > 0).astype(int)

--- a/g2_hurdle/model/regressor.py
+++ b/g2_hurdle/model/regressor.py
@@ -71,8 +71,13 @@ class HurdleRegressor:
                 common = X_tr.columns.intersection(X_va.columns, sort=False)
                 X_tr = X_tr[common]
                 X_va = X_va[common]
+        if isinstance(self.categorical_feature, list) and hasattr(X_tr, "columns"):
+            cats = [c for c in self.categorical_feature if c in X_tr.columns]
+        else:
+            cats = self.categorical_feature
+        if X_val is not None and y_val is not None:
             fit_params = {
-                "categorical_feature": self.categorical_feature,
+                "categorical_feature": cats,
                 "eval_set": [(X_va, y_va)],
             }
             if hasattr(X_tr, "columns"):
@@ -83,7 +88,7 @@ class HurdleRegressor:
                 fit_params["callbacks"] = callbacks
         else:
             fit_params = {
-                "categorical_feature": self.categorical_feature,
+                "categorical_feature": cats,
             }
             if hasattr(X_tr, "columns"):
                 fit_params["feature_name"] = list(X_tr.columns)


### PR DESCRIPTION
## Summary
- Filter regressor categorical feature list after removing constant columns and align train/validation columns
- Update classifier fit logic to filter categorical features post constant-column removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf6f5e2ea48328acb5937e6afad294