### PR TITLE
Parallelize rolling forecast CV loops

### DIFF
--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -2,6 +2,7 @@
 import os
 import numpy as np
 import pandas as pd
+from joblib import Parallel, delayed
 
 from ..utils.logging import get_logger
 from ..utils.timer import Timer
@@ -67,146 +68,162 @@ def run_train(cfg: dict):
     H = int(cfg.get("cv", {}).get("horizon", 7))
     init_ratio = float(cfg.get("cv", {}).get("init_train_ratio", 0.7))
     esr = int(cfg.get("cv", {}).get("early_stopping_rounds", 100))
+    n_jobs = int(cfg.get("runtime", {}).get("n_jobs", 1))
 
     y_true_all, p_all, q_all = [], [], []
+    preds_all = []
 
-    folds = 0
-    with Timer("Rolling CV"):
-        for tr_mask, va_mask, (tr_end, va_start, va_end) in rolling_forecast_origin_split(df, date_col, H, init_ratio):
-            folds += 1
-            df_tr = df.loc[tr_mask].copy()
-            df_va = df.loc[va_mask].copy()
-            # Split for early stopping inside training period
-            tr_inner, va_inner = _split_train_valid_by_tail_dates(df_tr, date_col, ratio_tail=28)
+    # Precompute splits so they can be processed in parallel
+    split_args = list(rolling_forecast_origin_split(df, date_col, H, init_ratio))
 
-            X_tr = X_all.loc[tr_inner.index, feature_cols]
-            y_tr = tr_inner[target_col].values
-            if va_inner is not None:
-                X_val = X_all.loc[va_inner.index, feature_cols]
-                y_val = va_inner[target_col].values
+    def _run_fold(split):
+        tr_mask, va_mask, (tr_end, va_start, va_end) = split
+        df_tr = df.loc[tr_mask].copy()
+        df_va = df.loc[va_mask].copy()
+        tr_inner, va_inner = _split_train_valid_by_tail_dates(df_tr, date_col, ratio_tail=28)
+
+        X_tr = X_all.loc[tr_inner.index, feature_cols]
+        y_tr = tr_inner[target_col].values
+        if va_inner is not None:
+            X_val = X_all.loc[va_inner.index, feature_cols]
+            y_val = va_inner[target_col].values
+        else:
+            X_val, y_val = None, None
+
+        min_pos_samples = int(cfg.get("cv", {}).get("min_positive_samples", 0))
+        min_neg_samples = int(cfg.get("cv", {}).get("min_negative_samples", 0))
+        y_tr_bin = (y_tr > 0)
+        unique = np.unique(y_tr_bin)
+        pos_count = int(y_tr_bin.sum())
+        neg_count = int(len(y_tr_bin) - pos_count)
+        skip_fold = False
+        if len(unique) < 2:
+            skip_fold = True
+            logger.warning(
+                f"Fold (train_end={tr_end.date()}): training data has a single class; skipping training.")
+        elif pos_count < min_pos_samples or neg_count < min_neg_samples:
+            skip_fold = True
+            logger.warning(
+                f"Fold (train_end={tr_end.date()}): only {pos_count} positive or {neg_count} negative samples; skipping training.")
+
+        preds_df = None
+        if not skip_fold:
+            drop_cols_tr = [c for c in X_tr.columns if X_tr[c].nunique(dropna=True) <= 1]
+            if drop_cols_tr:
+                X_tr = X_tr.drop(columns=drop_cols_tr)
+                if X_val is not None:
+                    X_val = X_val.drop(columns=drop_cols_tr, errors="ignore")
+            feature_cols_tr = [c for c in feature_cols if c not in drop_cols_tr]
+            categorical_cols_tr = [c for c in categorical_cols if c not in drop_cols_tr]
+            if not feature_cols_tr:
+                skip_fold = True
+                logger.warning(
+                    f"Fold (train_end={tr_end.date()}): no usable features after constant-column removal; skipping.")
             else:
-                X_val, y_val = None, None
+                X_tr = X_tr[feature_cols_tr]
+                if X_val is not None:
+                    X_val = X_val[feature_cols_tr]
 
-            min_pos_samples = int(cfg.get("cv", {}).get("min_positive_samples", 0))
-            min_neg_samples = int(cfg.get("cv", {}).get("min_negative_samples", 0))
-            y_tr_bin = (y_tr > 0)
-            unique = np.unique(y_tr_bin)
-            pos_count = int(y_tr_bin.sum())
-            neg_count = int(len(y_tr_bin) - pos_count)
-            skip_fold = False
-            if len(unique) < 2:
-                skip_fold = True
-                logger.warning(
-                    f"Fold (train_end={tr_end.date()}): training data has a single class; skipping training.")
-            elif pos_count < min_pos_samples or neg_count < min_neg_samples:
-                skip_fold = True
-                logger.warning(
-                    f"Fold (train_end={tr_end.date()}): only {pos_count} positive or {neg_count} negative samples; skipping training.")
+                if min_pos_ratio > 0:
+                    X_tr, y_tr = ensure_min_positive_ratio(X_tr, y_tr, min_pos_ratio, seed=seed)
 
-            preds_df = None
-            if not skip_fold:
-                drop_cols_tr = [c for c in X_tr.columns if X_tr[c].nunique(dropna=True) <= 1]
-                if drop_cols_tr:
-                    X_tr = X_tr.drop(columns=drop_cols_tr)
-                    if X_val is not None:
-                        X_val = X_val.drop(columns=drop_cols_tr, errors="ignore")
-                feature_cols_tr = [c for c in feature_cols if c not in drop_cols_tr]
-                categorical_cols_tr = [c for c in categorical_cols if c not in drop_cols_tr]
-                if not feature_cols_tr:
-                    skip_fold = True
-                    logger.warning(
-                        f"Fold (train_end={tr_end.date()}): no usable features after constant-column removal; skipping.")
-                else:
-                    X_tr = X_tr[feature_cols_tr]
-                    if X_val is not None:
-                        X_val = X_val[feature_cols_tr]
+                cat_tr = [c for c in categorical_cols_tr if c in X_tr.columns]
+                cls_params = dict(cfg.get("model", {}).get("classifier", {}))
+                reg_params = dict(cfg.get("model", {}).get("regressor", {}))
+                if cfg.get("runtime", {}).get("use_gpu", False):
+                    # Ensure GPU-specific defaults are present; adjust max_bin or num_leaves if OOM occurs
+                    cls_params.setdefault("device_type", "gpu")
+                    reg_params.setdefault("device_type", "gpu")
+                    cls_params.setdefault("gpu_use_dp", False)
+                    reg_params.setdefault("gpu_use_dp", False)
+                    cls_params.setdefault("max_bin", 255)
+                    reg_params.setdefault("max_bin", 255)
+                    cls_params.setdefault("feature_fraction", 0.8)
+                    reg_params.setdefault("feature_fraction", 0.8)
+                reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
 
-                    if min_pos_ratio > 0:
-                        X_tr, y_tr = ensure_min_positive_ratio(X_tr, y_tr, min_pos_ratio, seed=seed)
-
-                    cat_tr = [c for c in categorical_cols_tr if c in X_tr.columns]
-                    cls_params = dict(cfg.get("model", {}).get("classifier", {}))
-                    reg_params = dict(cfg.get("model", {}).get("regressor", {}))
-                    if cfg.get("runtime", {}).get("use_gpu", False):
-                        # Ensure GPU-specific defaults are present; adjust max_bin or num_leaves if OOM occurs
-                        cls_params.setdefault("device_type", "gpu")
-                        reg_params.setdefault("device_type", "gpu")
-                        cls_params.setdefault("gpu_use_dp", False)
-                        reg_params.setdefault("gpu_use_dp", False)
-                        cls_params.setdefault("max_bin", 255)
-                        reg_params.setdefault("max_bin", 255)
-                        cls_params.setdefault("feature_fraction", 0.8)
-                        reg_params.setdefault("feature_fraction", 0.8)
-                    reg = HurdleRegressor(reg_params, categorical_feature=cat_tr)
-
-                    # Fit regressor first
-                    with Timer(f"Fit fold (train_end={tr_end.date()}) - regressor"):
-                        reg.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
-                        reg.feature_names_ = list(
-                            getattr(getattr(reg, "model", reg), "feature_name_", getattr(reg, "feature_names_", []))
-                        )
-
-                    # Refit classifier on regressor-selected features
-                    reg_feats = list(getattr(reg, "feature_names_", []))
-                    X_tr = X_tr[reg_feats]
-                    if X_val is not None:
-                        X_val = X_val[reg_feats]
-                    cat_tr = [c for c in cat_tr if c in reg_feats]
-                    clf = HurdleClassifier(cls_params, categorical_feature=cat_tr)
-                    with Timer(f"Fit fold (train_end={tr_end.date()}) - classifier"):
-                        clf.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
-                        clf.feature_names_ = list(
-                            getattr(getattr(clf, "model", clf), "feature_name_", getattr(clf, "feature_names_", []))
-                        )
-
-                    # Recursive simulate on validation horizon per id using regressor feature list
-                    from .recursion import recursive_forecast_grouped
-                    # Use context: all rows up to tr_end per series
-                    context = df[df[date_col] <= tr_end].copy()
-                    preds_df = recursive_forecast_grouped(
-                        context,
-                        schema,
-                        cfg,
-                        clf,
-                        reg,
-                        threshold=0.5,
-                        horizon=H,
-                        feature_cols=reg_feats,
-                        categorical_cols=cat_tr,
+                # Fit regressor first
+                with Timer(f"Fit fold (train_end={tr_end.date()}) - regressor"):
+                    reg.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
+                    reg.feature_names_ = list(
+                        getattr(getattr(reg, "model", reg), "feature_name_", getattr(reg, "feature_names_", []))
                     )
-            if skip_fold:
-                ids = df_va["id"].unique()
-                preds_df = pd.DataFrame({"id": ids})
-                for i in range(1, H + 1):
-                    preds_df[f"D{i}"] = 0.0
-            # For threshold tuning we need y_true for validation horizon
-            # Construct ground truth for va period in wide form
-            va_truth = df_va.copy()
-            # Aggregate by id: collect 7 consecutive days
-            # We assume each id has continuous dates; map to D1..D7 relative ordering
-            truth_rows = []
-            for sid, g in va_truth.groupby("id"):
-                g = g.sort_values(date_col)
-                vals = g[target_col].values.tolist()
-                row = {"id": sid}
-                for i, v in enumerate(vals[:H], start=1):
-                    row[f"D{i}"] = v
-                truth_rows.append(row)
-            truth_df = pd.DataFrame(truth_rows)
 
-            merged = preds_df.merge(truth_df, on="id", how="inner", suffixes=("_pred","_true"))
+                # Refit classifier on regressor-selected features
+                reg_feats = list(getattr(reg, "feature_names_", []))
+                X_tr = X_tr[reg_feats]
+                if X_val is not None:
+                    X_val = X_val[reg_feats]
+                cat_tr = [c for c in cat_tr if c in reg_feats]
+                clf = HurdleClassifier(cls_params, categorical_feature=cat_tr)
+                with Timer(f"Fit fold (train_end={tr_end.date()}) - classifier"):
+                    clf.fit(X_tr, y_tr, X_val, y_val, early_stopping_rounds=esr)
+                    clf.feature_names_ = list(
+                        getattr(getattr(clf, "model", clf), "feature_name_", getattr(clf, "feature_names_", []))
+                    )
+
+                # Recursive simulate on validation horizon per id using regressor feature list
+                from .recursion import recursive_forecast_grouped
+                # Use context: all rows up to tr_end per series
+                context = df[df[date_col] <= tr_end].copy()
+                preds_df = recursive_forecast_grouped(
+                    context,
+                    schema,
+                    cfg,
+                    clf,
+                    reg,
+                    threshold=0.5,
+                    horizon=H,
+                    feature_cols=reg_feats,
+                    categorical_cols=cat_tr,
+                )
+        if skip_fold:
+            ids = df_va["id"].unique()
+            preds_df = pd.DataFrame({"id": ids})
             for i in range(1, H + 1):
-                yp = merged[f"D{i}_pred"].values
-                yt = merged[f"D{i}_true"].values
-                if skip_fold:
-                    p_all.extend(np.zeros_like(yt))
-                    q_all.extend(np.zeros_like(yt))
-                else:
-                    # For tuning, we approximate p and q by using yp as reg outcome and assume proba ~1 if yp>0 else 0.3
-                    # (Simplification: exact p,q not returned from recursion; keeping interface lean.)
-                    p_all.extend((yp > 0).astype(float) * 0.7 + 0.3 * (yp <= 0))
-                    q_all.extend(yp)
-                y_true_all.extend(yt)
+                preds_df[f"D{i}"] = 0.0
+        # For threshold tuning we need y_true for validation horizon
+        # Construct ground truth for va period in wide form
+        va_truth = df_va.copy()
+        truth_rows = []
+        for sid, g in va_truth.groupby("id"):
+            g = g.sort_values(date_col)
+            vals = g[target_col].values.tolist()
+            row = {"id": sid}
+            for i, v in enumerate(vals[:H], start=1):
+                row[f"D{i}"] = v
+            truth_rows.append(row)
+        truth_df = pd.DataFrame(truth_rows)
+
+        merged = preds_df.merge(truth_df, on="id", how="inner", suffixes=("_pred","_true"))
+        y_true_fold, p_fold, q_fold = [], [], []
+        for i in range(1, H + 1):
+            yp = merged[f"D{i}_pred"].values
+            yt = merged[f"D{i}_true"].values
+            if skip_fold:
+                p_fold.extend(np.zeros_like(yt))
+                q_fold.extend(np.zeros_like(yt))
+            else:
+                # For tuning, we approximate p and q by using yp as reg outcome and assume proba ~1 if yp>0 else 0.3
+                # (Simplification: exact p,q not returned from recursion; keeping interface lean.)
+                p_fold.extend((yp > 0).astype(float) * 0.7 + 0.3 * (yp <= 0))
+                q_fold.extend(yp)
+            y_true_fold.extend(yt)
+
+        return preds_df, y_true_fold, p_fold, q_fold
+
+    with Timer("Rolling CV"):
+        if n_jobs == 1:
+            fold_outputs = [_run_fold(s) for s in split_args]
+        else:
+            fold_outputs = Parallel(n_jobs=n_jobs)(delayed(_run_fold)(s) for s in split_args)
+
+    folds = len(fold_outputs)
+    for preds_df, y_true_fold, p_fold, q_fold in fold_outputs:
+        preds_all.append(preds_df)
+        y_true_all.extend(y_true_fold)
+        p_all.extend(p_fold)
+        q_all.extend(q_fold)
 
     with Timer("Threshold search"):
         from ..model.threshold import find_optimal_threshold


### PR DESCRIPTION
## Summary
- Parallelize rolling-origin cross-validation folds with joblib
- Collect fold outputs safely and expose n_jobs config parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf7959f8108328887173c18d088c99