### PR TITLE
refactor: centralize series name normalization

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -7,7 +7,12 @@ import pandas as pd
 from ..utils.logging import get_logger
 from ..utils.timer import Timer
 from ..utils.io import load_artifacts, load_data
-from ..utils.keys import build_series_id, align_to_submission, ensure_wide_columns
+from ..utils.keys import (
+    build_series_id,
+    align_to_submission,
+    ensure_wide_columns,
+    normalize_series_name,
+)
 from ..fe import run_feature_engineering, prepare_features
 from .recursion import recursive_forecast_grouped
 
@@ -91,7 +96,7 @@ def run_predict(cfg: dict):
         out = sub.rename(columns={row_key_col: "row_key"}).copy()
 
         # Normalize menu column names to match prediction ids
-        menu_map = {c: re.sub(r"\s+", "_", str(c).strip()) for c in menu_cols}
+        menu_map = {c: normalize_series_name(c) for c in menu_cols}
 
         for idx, row in out.iterrows():
             row_key = row["row_key"]

--- a/g2_hurdle/utils/keys.py
+++ b/g2_hurdle/utils/keys.py
@@ -1,6 +1,13 @@
 
 import pandas as pd
 import numpy as np
+import re
+
+def normalize_series_name(s):
+    if isinstance(s, pd.Series):
+        return s.astype(str).str.strip().str.replace(r"\s+", "_", regex=True)
+    return re.sub(r"\s+", "_", str(s).strip())
+
 
 def build_series_id(df: pd.DataFrame, series_cols):
     if not series_cols:
@@ -8,8 +15,7 @@ def build_series_id(df: pd.DataFrame, series_cols):
         return pd.Series(["__single__"]*len(df), index=df.index)
     parts = []
     for c in series_cols:
-        s = df[c].astype(str).str.strip().str.replace(r"\s+", "_", regex=True)
-        parts.append(s)
+        parts.append(normalize_series_name(df[c]))
     key = parts[0]
     for s in parts[1:]:
         key = key + "__" + s


### PR DESCRIPTION
## Summary
- add `normalize_series_name` helper for consistent series naming
- reuse helper in `build_series_id` and prediction menu mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf8a0ffb9c83289740db7b44e8c448