### PR TITLE
Handle UTF-8 BOM when loading sample submission

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -88,7 +88,7 @@ def run_predict(cfg: dict):
 
     preds = pd.concat(pred_all.values(), ignore_index=True)
     # Load sample submission and align
-    sub = pd.read_csv(sample_path)
+    sub = pd.read_csv(sample_path, encoding="utf-8-sig", dtype=str)
     id_col = "id" if "id" in sub.columns else None
     if id_col is None:
         row_key_col = sub.columns[0]


### PR DESCRIPTION
## Summary
- Ensure sample submission CSV is read using UTF-8 with BOM and keep column values as strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf90cfa6388328858f3497e5db779f