### PR TITLE
Add holidayskr to dependency list

### DIFF
--- a/dependency.py
+++ b/dependency.py
@@ -8,6 +8,7 @@ REQUIRED_PACKAGES = [
     "lightgbm",
     "pyyaml",  # for reading YAML configuration files
     "scikit-learn",  # optional utilities for model evaluation
+    "holidayskr",
 ]
 
 def install_missing_packages(packages):


### PR DESCRIPTION
## Summary
- include `holidayskr` in the required packages list

## Testing
- `python - <<'PY'
from holidayskr import is_holiday
print(is_holiday('2023-01-01'))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0d86f7720832887b03d01e298e760