### PR TITLE
Enable holiday features by default

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -19,7 +19,8 @@ features:
   fourier: { weekly_K: 3, yearly_K: 10 }
   lags: [1,2,7,14,28,365]
   rollings: [7,14,28]
-  use_holidays: false
+  # Whether to include holiday-based features. Set to false to disable.
+  use_holidays: true
   intermittency: { enable: true }
 
 model:

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -19,7 +19,8 @@ features:
   fourier: { weekly_K: 3, yearly_K: 10 }
   lags: [1,2,7,14,28,365]
   rollings: [7,14,28]
-  use_holidays: false
+  # Whether to include holiday-based features. Set to false to disable.
+  use_holidays: true
   intermittency: { enable: true }
 
 model:


### PR DESCRIPTION
## Summary
- enable holiday-based features in default and Korean configs
- add comments so flag can be toggled off if needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0d933450c8328899b171b398fa987