### PR TITLE
Add configurable holiday features

### DIFF
--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -13,8 +13,11 @@ def run_feature_engineering(df: pd.DataFrame, cfg: dict, schema: dict) -> pd.Dat
     series_cols = schema["series"]
     out = df.copy()
     out = create_calendar_features(out, date_col)
-    if cfg.get("features", {}).get("use_holidays", True):
+    if cfg.get("features", {}).get("use_holidays"):
         out = create_holiday_features(out, date_col)
+    else:
+        out["is_holiday"] = 0
+        out["holiday_name"] = pd.Series(["None"] * len(out), dtype="category")
     out = create_fourier_features(out, date_col, cfg)
     out = create_lags_and_rolling_features(out, target_col, series_cols, cfg)
     if cfg.get("features", {}).get("intermittency", {}).get("enable", True):


### PR DESCRIPTION
## Summary
- expose holiday feature generation behind cfg["features"]["use_holidays"]
- supply default `is_holiday` and `holiday_name` columns when holiday features disabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0da7c63d08328906ebd416b39e34a