### PR TITLE
Add holiday feature support to static future features

### DIFF
--- a/g2_hurdle/fe/static.py
+++ b/g2_hurdle/fe/static.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from .calendar import create_calendar_features
 from .fourier import create_fourier_features
+from .holiday import create_holiday_features
 
 
 def prepare_static_future_features(df: pd.DataFrame, schema: dict, cfg: dict, horizon: int) -> pd.DataFrame:
@@ -29,6 +30,8 @@ def prepare_static_future_features(df: pd.DataFrame, schema: dict, cfg: dict, ho
     future_dates = pd.date_range(last_date + pd.Timedelta(days=1), periods=horizon, freq="D")
     future_df = pd.DataFrame({date_col: future_dates})
     out = create_calendar_features(future_df, date_col)
+    if cfg.get("features", {}).get("use_holidays"):
+        out = create_holiday_features(out, date_col)
     out = create_fourier_features(out, date_col, cfg)
     out = out.set_index(date_col)
     return out


### PR DESCRIPTION
## Summary
- import `create_holiday_features` in static feature generator
- optionally add holiday features for future dates when `use_holidays` enabled while preserving date index

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0db4d9e8c8328a640c16539ae70c4