### PR TITLE
Add holiday_name to categorical feature base

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -34,7 +34,7 @@ def run_predict(cfg: dict):
         features_meta = art.get("features.json", {})
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
-        base_cats = ["dow", "week", "month", "quarter"]
+        base_cats = ["dow", "week", "month", "quarter", "holiday_name"]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         train_cfg = art.get("config.json", {})
         if "features" in train_cfg:
@@ -71,7 +71,11 @@ def run_predict(cfg: dict):
             *schema_use["series"],
             "id",
         ]
-        prepare_features(fe, drop_cols, feature_cols, categorical_cols)
+        X_test, _, _ = prepare_features(fe, drop_cols, feature_cols, categorical_cols)
+        if "holiday_name" in X_test.columns:
+            assert pd.api.types.is_categorical_dtype(
+                X_test["holiday_name"]
+            ), "holiday_name should be categorical after prepare_features"
 
         preds_df = recursive_forecast_grouped(
             df,

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -61,8 +61,12 @@ def run_train(cfg: dict):
         drop_cols = [date_col, target_col] + series_cols + ["id"]
         X_all, feature_cols, categorical_cols = prepare_features(fe, drop_cols)
         # ensure calendar components are treated as categorical features
-        base_cats = [c for c in ["dow", "week", "month", "quarter"] if c in X_all.columns]
+        base_cats = [c for c in ["dow", "week", "month", "quarter", "holiday_name"] if c in X_all.columns]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
+        if "holiday_name" in X_all.columns:
+            assert pd.api.types.is_categorical_dtype(
+                X_all["holiday_name"]
+            ), "holiday_name should be categorical after prepare_features"
         y_all = df[target_col].values
 
     H = int(cfg.get("cv", {}).get("horizon", 7))


### PR DESCRIPTION
## Summary
- ensure holiday_name is treated as a categorical feature during training and prediction
- verify holiday_name column retains categorical dtype after feature preparation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0dc0c466c832880b27557c277e7f3