### PR TITLE
test: remove holiday monkeypatch

### DIFF
--- a/tests/test_holiday_features.py
+++ b/tests/test_holiday_features.py
@@ -1,19 +1,9 @@
 import pandas as pd
-import holidayskr
 from g2_hurdle.fe import run_feature_engineering
 
 
-def test_holiday_features(monkeypatch):
+def test_holiday_features():
     """run_feature_engineering should mark holidays correctly."""
-
-    original_is_holiday = holidayskr.is_holiday
-
-    def _patched(date):
-        if not isinstance(date, str):
-            date = date.strftime("%Y-%m-%d")
-        return original_is_holiday(date)
-
-    monkeypatch.setattr(holidayskr, "is_holiday", _patched)
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- simplify holiday feature test by removing unnecessary monkeypatch wrapper
- verify `run_feature_engineering` sets `is_holiday` and `holiday_name` columns

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0e16d74cc8328a1e8f68b996ee3e0