### PR TITLE
Include identifiers as categorical features

### DIFF
--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -5,6 +5,9 @@ import pandas as pd
 def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categorical_cols=None):
     X = fe_df.drop(columns=[c for c in drop_cols if c in fe_df.columns], errors="ignore").copy()
     X = X.replace([np.inf, -np.inf], np.nan)
+    for c in ["store_id", "menu_id"]:
+        if c in X.columns:
+            X[c] = X[c].astype("category")
     # Handle missing values separately for categorical and non-categorical columns
     cat_cols = X.select_dtypes(include="category").columns
     obj_cols = X.select_dtypes(include="object").columns

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -68,8 +68,8 @@ def run_predict(cfg: dict):
         drop_cols = [
             schema_use["date"],
             schema_use["target"],
-            *schema_use["series"],
             "id",
+            *[c for c in schema_use["series"] if c not in ("store_id", "menu_id")],
         ]
         X_test, _, _ = prepare_features(fe, drop_cols, feature_cols, categorical_cols)
         if "holiday_name" in X_test.columns:

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -58,7 +58,12 @@ def run_train(cfg: dict):
 
     with Timer("Feature engineering"):
         fe = run_feature_engineering(df, cfg, schema)
-        drop_cols = [date_col, target_col] + series_cols + ["id"]
+        drop_cols = [
+            date_col,
+            target_col,
+            "id",
+            *[c for c in series_cols if c not in ("store_id", "menu_id")],
+        ]
         X_all, feature_cols, categorical_cols = prepare_features(fe, drop_cols)
         # ensure calendar components are treated as categorical features
         base_cats = [c for c in ["dow", "week", "month", "quarter", "holiday_name"] if c in X_all.columns]


### PR DESCRIPTION
## Summary
- Preserve `store_id` and `menu_id` as features and treat them as categorical values.
- Ensure inference pipeline retains these identifiers and casts them appropriately.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fa8955088328a134a77bf86d2cd6