### PR TITLE
feat: add group aggregate features

### DIFF
--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -4,6 +4,7 @@ from .calendar import create_calendar_features
 from .fourier import create_fourier_features
 from .holiday import create_holiday_features
 from .lags_rolling import create_lags_and_rolling_features
+from .group_aggregate import create_group_aggregate_features
 from .intermittency import create_intermittency_features
 from .preprocess import prepare_features
 from .embeddings import create_embedding_features
@@ -26,6 +27,7 @@ def run_feature_engineering(
         out["is_holiday"] = 0
         out["holiday_name"] = pd.Series(["None"] * len(out), dtype="category")
     out = create_fourier_features(out, date_col, cfg)
+    out = create_group_aggregate_features(out, target_col)
     out = create_lags_and_rolling_features(out, target_col, series_cols, cfg)
     if cfg.get("features", {}).get("embeddings", {}).get("enable", True):
         emb_cols = [c for c in ("store_id", "menu_id") if c in series_cols]

--- a/g2_hurdle/fe/group_aggregate.py
+++ b/g2_hurdle/fe/group_aggregate.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+
+def create_group_aggregate_features(df: pd.DataFrame, target_col: str) -> pd.DataFrame:
+    """Add store-level and menu-level aggregate features.
+
+    For each of ``store_id`` and ``menu_id`` present in ``df``, compute the
+    mean and standard deviation of the target column across the entire history
+    and merge them back onto the dataframe.  Missing values are filled with 0
+    so the resulting features are numeric and ready for modelling.
+    """
+    out = df.copy()
+    added_cols = []
+    for col in ("store_id", "menu_id"):
+        if col in out.columns:
+            stats = (
+                out.groupby(col, observed=False)[target_col]
+                .agg(["mean", "std"])
+                .rename(columns={"mean": f"{col}_avg_sales", "std": f"{col}_volatility"})
+            )
+            out = out.merge(stats, how="left", left_on=col, right_index=True)
+            added_cols.extend(stats.columns)
+    if added_cols:
+        out[added_cols] = out[added_cols].fillna(0)
+    return out

--- a/g2_hurdle/fe/static.py
+++ b/g2_hurdle/fe/static.py
@@ -5,7 +5,13 @@ from .fourier import create_fourier_features
 from .holiday import create_holiday_features
 
 
-def prepare_static_future_features(df: pd.DataFrame, schema: dict, cfg: dict, horizon: int) -> pd.DataFrame:
+def prepare_static_future_features(
+    df: pd.DataFrame,
+    schema: dict,
+    cfg: dict,
+    horizon: int,
+    extra_cols: dict | None = None,
+) -> pd.DataFrame:
     """Pre-compute calendar and Fourier features for all future dates.
 
     Parameters
@@ -33,5 +39,8 @@ def prepare_static_future_features(df: pd.DataFrame, schema: dict, cfg: dict, ho
     if cfg.get("features", {}).get("use_holidays"):
         out = create_holiday_features(out, date_col)
     out = create_fourier_features(out, date_col, cfg)
+    if extra_cols:
+        for k, v in extra_cols.items():
+            out[k] = v
     out = out.set_index(date_col)
     return out

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -232,6 +232,22 @@ def recursive_forecast_grouped(
     context_df = context_df.copy()
     context_df["_series_id"] = id_series
 
+    # Pre-compute aggregate stats for store_id and menu_id if available
+    store_stats = None
+    menu_stats = None
+    if "store_id" in context_df.columns:
+        store_stats = (
+            context_df.groupby("store_id", observed=False)[target_col]
+            .agg(["mean", "std"])
+            .rename(columns={"mean": "store_id_avg_sales", "std": "store_id_volatility"})
+        )
+    if "menu_id" in context_df.columns:
+        menu_stats = (
+            context_df.groupby("menu_id", observed=False)[target_col]
+            .agg(["mean", "std"])
+            .rename(columns={"mean": "menu_id_avg_sales", "std": "menu_id_volatility"})
+        )
+
     drop_cols = [date_col, target_col, *series_cols]
     lags = cfg.get("features", {}).get("lags", [1, 2, 7, 14, 28, 365])
     rolls = cfg.get("features", {}).get("rollings", [7, 14, 28])
@@ -251,10 +267,24 @@ def recursive_forecast_grouped(
         g = g.sort_values(date_col).copy()
         last_date = g[date_col].max()
 
-        static_feats = static_cache.get(last_date)
-        if static_feats is None:
-            static_feats = prepare_static_future_features(g, schema, cfg, H)
-            static_cache[last_date] = static_feats
+        # gather aggregate features for this series
+        extra_cols = {}
+        if store_stats is not None and "store_id" in g.columns:
+            s_id = g["store_id"].iloc[0]
+            if s_id in store_stats.index:
+                extra_cols.update(store_stats.loc[s_id].to_dict())
+        if menu_stats is not None and "menu_id" in g.columns:
+            m_id = g["menu_id"].iloc[0]
+            if m_id in menu_stats.index:
+                extra_cols.update(menu_stats.loc[m_id].to_dict())
+
+        base_static = static_cache.get(last_date)
+        if base_static is None:
+            base_static = prepare_static_future_features(g, schema, cfg, H)
+            static_cache[last_date] = base_static
+        static_feats = base_static.copy()
+        for k, v in extra_cols.items():
+            static_feats[k] = v
         static_frames[sid] = static_feats
 
         y = g[target_col].astype(np.float32).values

--- a/tests/test_group_aggregate_features.py
+++ b/tests/test_group_aggregate_features.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+
+from g2_hurdle.fe.group_aggregate import create_group_aggregate_features
+
+
+def test_group_aggregate_features():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=4),
+            "store_id": ["A", "A", "B", "B"],
+            "menu_id": ["X", "Y", "X", "Y"],
+            "sales": [1, 2, 3, 4],
+        }
+    )
+    out = create_group_aggregate_features(df, "sales")
+    row_a = out[out["store_id"] == "A"].iloc[0]
+    assert np.isclose(row_a["store_id_avg_sales"], 1.5)
+    assert np.isclose(row_a["store_id_volatility"], np.std([1, 2], ddof=1))
+    row_x = out[out["menu_id"] == "X"].iloc[0]
+    assert np.isclose(row_x["menu_id_avg_sales"], 2.0)
+    assert np.isclose(row_x["menu_id_volatility"], np.std([1, 3], ddof=1))


### PR DESCRIPTION
## Summary
- compute store and menu level aggregate metrics prior to lag/rolling features
- include aggregates in future static feature prep and recursion forecasting
- add tests for group aggregate feature computation

## Testing
- `python -m pytest tests/test_group_aggregate_features.py::test_group_aggregate_features -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fd384cbc83288b90e82d02b892e8