### PR TITLE
Add embedding-aware recursion features

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -88,6 +88,7 @@ def run_predict(cfg: dict):
             horizon=H,
             feature_cols=feature_cols,
             categorical_cols=categorical_cols,
+            embedding_map=embedding_map,
         )
         pred_all[test_name] = preds_df
 

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -188,6 +188,7 @@ def run_train(cfg: dict):
                     horizon=H,
                     feature_cols=reg_feats,
                     categorical_cols=cat_tr,
+                    embedding_map=embed_map,
                 )
         if skip_fold:
             ids = df_va["id"].unique()


### PR DESCRIPTION
## Summary
- Allow recursive forecasts to accept an `embedding_map` and attach store/menu embeddings to static features
- Retain `store_id` and `menu_id` as categorical features in recursive forecasting
- Pass the `embedding_map` through training and prediction pipelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1004d558c832895cd5e394f1df253