### PR TITLE
feat: replace embeddings with target encoding features

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -22,7 +22,7 @@ features:
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: true
   intermittency: { enable: true }
-  embeddings: { dim: 8 }
+  target_encoding: { smoothing: 10.0 }
 
 model:
   classifier:

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -22,6 +22,7 @@ features:
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: false
   intermittency: { enable: true }
+  target_encoding: { smoothing: 10.0 }
 
 model:
   classifier:

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -39,7 +39,7 @@ def run_predict(cfg: dict):
         train_cfg = art.get("config.json", {})
         if "features" in train_cfg:
             cfg["features"] = train_cfg["features"]
-        embedding_map = art.get("embeddings.json", {})
+        target_encoding_map = art.get("target_encoding.json", {})
 
     H = int(cfg.get("cv", {}).get("horizon", 7))
 
@@ -65,7 +65,7 @@ def run_predict(cfg: dict):
 
         # Optionally compute features to ensure column alignment
         schema_use = schema or _schema
-        fe, _ = run_feature_engineering(df, cfg, schema_use, embedding_map)
+        fe, _ = run_feature_engineering(df, cfg, schema_use, target_encoding_map)
         drop_cols = [
             schema_use["date"],
             schema_use["target"],
@@ -88,7 +88,7 @@ def run_predict(cfg: dict):
             horizon=H,
             feature_cols=feature_cols,
             categorical_cols=categorical_cols,
-            embedding_map=embedding_map,
+            target_encoding_map=target_encoding_map,
         )
         pred_all[test_name] = preds_df
 

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -64,7 +64,7 @@ def run_train(cfg: dict):
     seed = int(cfg.get("runtime", {}).get("seed", 42))
 
     with Timer("Feature engineering"):
-        fe, embed_map = run_feature_engineering(df, cfg, schema)
+        fe, target_encoding_map = run_feature_engineering(df, cfg, schema)
         drop_cols = [
             date_col,
             target_col,
@@ -223,7 +223,7 @@ def run_train(cfg: dict):
                     horizon=H,
                     feature_cols=reg_feats,
                     categorical_cols=cat_tr,
-                    embedding_map=embed_map,
+                    target_encoding_map=target_encoding_map,
                 )
         if skip_fold:
             ids = df_va["id"].unique()
@@ -389,7 +389,7 @@ def run_train(cfg: dict):
         "config.json": cfg,
         "version.txt": f"generated_by=g2_hurdle; folds={folds}",
         "features.json": {"feature_cols": feature_cols, "categorical_cols": categorical_cols},
-        "embeddings.json": embed_map,
+        "target_encoding.json": target_encoding_map,
     }
     save_artifacts(artifacts, artifacts_dir)
     logger.info("Training complete.")


### PR DESCRIPTION
## Summary
- add time-aware target encoding with smoothing for store and menu IDs
- use target encoding features throughout training, prediction, and recursion
- save/load target encoding mappings in pipeline artifacts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c12815db8c832894cd2950d86832a4