### PR TITLE
Simplify category mapping in feature preprocessing

### DIFF
--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -49,7 +49,7 @@ def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categori
                 X[c] = (
                     X[c]
                     .astype("category")
-                    .cat.set_categories(cats, inplace=False)
+                    .cat.set_categories(cats)
                     .fillna("missing")
                 )
 


### PR DESCRIPTION
## Summary
- Drop unnecessary `inplace=False` in `set_categories` call within feature preprocessing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20da0dab88328ab1e36b43e59e8d5