### PR TITLE
Split store and menu identifiers for target encoding

### DIFF
--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -11,7 +11,7 @@ io:
 data:
   date_col_candidates: ["영업일자"]
   target_col_candidates: ["매출수량"]
-  id_col_candidates: ["영업장명_메뉴명"]
+  id_col_candidates: ["영업장명_메뉴명", "store_id", "menu_id"]
   min_context_days: 7
   min_positive_ratio: 0.01
 

--- a/g2_hurdle/utils/io.py
+++ b/g2_hurdle/utils/io.py
@@ -7,6 +7,11 @@ logger = get_logger("IO")
 
 def load_data(path: str, cfg: dict):
     df = pd.read_csv(path)
+    combined_col = "영업장명_메뉴명"
+    if combined_col in df.columns:
+        splits = df[combined_col].astype(str).str.split("_", n=1, expand=True)
+        df["store_id"] = splits[0]
+        df["menu_id"] = splits[1]
     schema = resolve_schema(df.columns.tolist(), cfg)
     date_col = schema["date"]
     target_col = schema["target"]

--- a/tests/test_io_split_ids.py
+++ b/tests/test_io_split_ids.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from g2_hurdle.utils.io import load_data
+
+def test_load_data_splits_store_menu(tmp_path):
+    df = pd.DataFrame({
+        "영업일자": pd.to_datetime(["2024-01-01"]),
+        "매출수량": [1],
+        "영업장명_메뉴명": ["s1_m1"],
+    })
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    cfg = {
+        "data": {
+            "date_col_candidates": ["영업일자"],
+            "target_col_candidates": ["매출수량"],
+            "id_col_candidates": ["영업장명_메뉴명", "store_id", "menu_id"],
+        },
+    }
+    out, schema = load_data(str(csv_path), cfg)
+    assert out.loc[0, "store_id"] == "s1"
+    assert out.loc[0, "menu_id"] == "m1"
+    assert "store_id" in schema["series"]
+    assert "menu_id" in schema["series"]

--- a/tests/test_run_feature_engineering_target_encoding.py
+++ b/tests/test_run_feature_engineering_target_encoding.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from g2_hurdle.fe import run_feature_engineering
+
+def test_run_feature_engineering_adds_target_encoding():
+    df = pd.DataFrame({
+        "d": pd.to_datetime([
+            "2024-01-01",
+            "2024-01-02",
+            "2024-01-03",
+            "2024-01-04",
+        ]),
+        "y": [1, 0, 2, 1],
+        "store_id": ["s1", "s1", "s2", "s2"],
+        "menu_id": ["m1", "m2", "m1", "m3"],
+    })
+    cfg = {
+        "features": {
+            "use_holidays": False,
+            "lags": [],
+            "rollings": [],
+            "fourier": {"weekly_K": 0, "yearly_K": 0},
+            "intermittency": {"enable": False},
+            "target_encoding": {"smoothing": 0},
+        }
+    }
+    schema = {"date": "d", "target": "y", "series": ["store_id", "menu_id"]}
+    result, mapping = run_feature_engineering(df, cfg, schema)
+    assert "store_id_te_mean" in result.columns
+    assert "menu_id_te_mean" in result.columns
+    assert "store_id" in mapping
+    assert "menu_id" in mapping


### PR DESCRIPTION
## Summary
- Split combined `영업장명_메뉴명` column into `store_id` and `menu_id` during data load
- Allow `store_id` and `menu_id` as identifier candidates in Korean config
- Test data loading split and target encoding feature generation

## Testing
- `PYTHONPATH=. pytest tests/test_io_split_ids.py tests/test_run_feature_engineering_target_encoding.py -q`
- `PYTHONPATH=. pytest -q` *(fails: lightgbm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c211630c048328b3476618306e76fb