### PR TITLE
Preserve categorical dtypes during resampling

### DIFF
--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -184,6 +184,10 @@ def run_train(cfg: dict):
 
                 if min_pos_ratio > 0:
                     X_tr, y_tr = ensure_min_positive_ratio(X_tr, y_tr, min_pos_ratio, seed=seed)
+                    # Verify categorical dtypes are preserved after resampling
+                    for col in ["store_id", "menu_id"]:
+                        if col in X_tr.columns:
+                            logger.debug(f"{col} dtype after ensure_min_positive_ratio: {X_tr[col].dtype}")
 
                 cat_tr = [c for c in categorical_cols_tr if c in X_tr.columns]
                 cls_params = dict(cfg.get("model", {}).get("classifier", {}))

--- a/g2_hurdle/utils/preprocessing.py
+++ b/g2_hurdle/utils/preprocessing.py
@@ -30,6 +30,9 @@ def ensure_min_positive_ratio(
     Tuple[pd.DataFrame, np.ndarray]
         Augmented ``X`` and ``y`` with additional positive samples if needed.
     """
+    # Preserve original categorical columns to restore dtypes after augmentation
+    cat_cols = X.select_dtypes(include="category").columns
+
     if min_ratio <= 0:
         return X, y
 
@@ -56,4 +59,9 @@ def ensure_min_positive_ratio(
     y_extra = y[extra_indices]
     X_aug = pd.concat([X, X_extra], ignore_index=True)
     y_aug = np.concatenate([y, y_extra])
+
+    # Restore categorical dtypes using original category definitions
+    for c in cat_cols:
+        X_aug[c] = pd.Categorical(X_aug[c], categories=X[c].cat.categories)
+
     return X_aug, y_aug


### PR DESCRIPTION
## Summary
- Preserve and restore categorical dtypes in `ensure_min_positive_ratio` to avoid dtype degradation after augmentation
- Add debug logging in cross-validation `_run_fold` to confirm `store_id` and `menu_id` remain categorical after resampling

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c213fe9f5c8328bb6f36bc0bdf37c6