### PR TITLE
Add combined store_menu_id and update target encoding

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -11,7 +11,7 @@ io:
 data:
   date_col_candidates: ["date","ds"]
   target_col_candidates: ["sales","y","target"]
-  id_col_candidates: ["store_id","menu_id","series_id","영업장명","메뉴명"]
+  id_col_candidates: ["store_id","menu_id","store_menu_id","series_id","영업장명","메뉴명"]
   min_context_days: 7
   min_positive_ratio: 0.01
 

--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -11,7 +11,7 @@ io:
 data:
   date_col_candidates: ["영업일자"]
   target_col_candidates: ["매출수량"]
-  id_col_candidates: ["영업장명_메뉴명", "store_id", "menu_id"]
+  id_col_candidates: ["영업장명_메뉴명", "store_id", "menu_id", "store_menu_id"]
   min_context_days: 7
   min_positive_ratio: 0.01
 

--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -30,7 +30,9 @@ def run_feature_engineering(
     # the training portion of the data to avoid leakage.
     out = create_lags_and_rolling_features(out, target_col, series_cols, cfg)
     if cfg.get("features", {}).get("target_encoding", {}).get("enable", True):
-        te_cols = [c for c in ("store_id", "menu_id") if c in series_cols]
+        te_cols = [
+            c for c in ("store_id", "menu_id", "store_menu_id") if c in series_cols
+        ]
         out, target_encoding_map = create_target_encoding_features(
             out, te_cols, target_col, date_col, cfg, target_encoding_map
         )

--- a/g2_hurdle/utils/io.py
+++ b/g2_hurdle/utils/io.py
@@ -12,6 +12,10 @@ def load_data(path: str, cfg: dict):
         splits = df[combined_col].astype(str).str.split("_", n=1, expand=True)
         df["store_id"] = splits[0]
         df["menu_id"] = splits[1]
+    if "store_id" in df.columns and "menu_id" in df.columns:
+        df["store_menu_id"] = (
+            df["store_id"].astype(str) + "_" + df["menu_id"].astype(str)
+        )
     schema = resolve_schema(df.columns.tolist(), cfg)
     date_col = schema["date"]
     target_col = schema["target"]

--- a/tests/test_io_split_ids.py
+++ b/tests/test_io_split_ids.py
@@ -13,11 +13,18 @@ def test_load_data_splits_store_menu(tmp_path):
         "data": {
             "date_col_candidates": ["영업일자"],
             "target_col_candidates": ["매출수량"],
-            "id_col_candidates": ["영업장명_메뉴명", "store_id", "menu_id"],
+            "id_col_candidates": [
+                "영업장명_메뉴명",
+                "store_id",
+                "menu_id",
+                "store_menu_id",
+            ],
         },
     }
     out, schema = load_data(str(csv_path), cfg)
     assert out.loc[0, "store_id"] == "s1"
     assert out.loc[0, "menu_id"] == "m1"
+    assert out.loc[0, "store_menu_id"] == "s1_m1"
     assert "store_id" in schema["series"]
     assert "menu_id" in schema["series"]
+    assert "store_menu_id" in schema["series"]

--- a/tests/test_run_feature_engineering_target_encoding.py
+++ b/tests/test_run_feature_engineering_target_encoding.py
@@ -12,6 +12,7 @@ def test_run_feature_engineering_adds_target_encoding():
         "y": [1, 0, 2, 1],
         "store_id": ["s1", "s1", "s2", "s2"],
         "menu_id": ["m1", "m2", "m1", "m3"],
+        "store_menu_id": ["s1_m1", "s1_m2", "s2_m1", "s2_m3"],
     })
     cfg = {
         "features": {
@@ -23,9 +24,15 @@ def test_run_feature_engineering_adds_target_encoding():
             "target_encoding": {"smoothing": 0},
         }
     }
-    schema = {"date": "d", "target": "y", "series": ["store_id", "menu_id"]}
+    schema = {
+        "date": "d",
+        "target": "y",
+        "series": ["store_id", "menu_id", "store_menu_id"],
+    }
     result, mapping = run_feature_engineering(df, cfg, schema)
     assert "store_id_te_mean" in result.columns
     assert "menu_id_te_mean" in result.columns
+    assert "store_menu_id_te_mean" in result.columns
     assert "store_id" in mapping
     assert "menu_id" in mapping
+    assert "store_menu_id" in mapping

--- a/tests/test_target_encoding_features.py
+++ b/tests/test_target_encoding_features.py
@@ -12,13 +12,14 @@ def test_target_encoding_features_with_mapping_and_unseen():
             ),
             "store_id": [1, 1, 2, 2],
             "menu_id": [10, 20, 10, 30],
+            "store_menu_id": ["1_10", "1_20", "2_10", "2_30"],
             "y": [1, 2, 3, 4],
         }
     )
     cfg = {"features": {"target_encoding": {"smoothing": 0}}}
 
     out, mapping = create_target_encoding_features(
-        df, ["store_id", "menu_id"], "y", "d", cfg, None
+        df, ["store_id", "menu_id", "store_menu_id"], "y", "d", cfg, None
     )
 
     # Check that expected columns exist
@@ -27,6 +28,8 @@ def test_target_encoding_features_with_mapping_and_unseen():
         "store_id_te_std",
         "menu_id_te_mean",
         "menu_id_te_std",
+        "store_menu_id_te_mean",
+        "store_menu_id_te_std",
     ]:
         assert col in out.columns
 
@@ -35,17 +38,26 @@ def test_target_encoding_features_with_mapping_and_unseen():
     assert np.allclose(out["store_id_te_std"], [0.0, 0.0, 0.5, 0.0])
     assert np.allclose(out["menu_id_te_mean"], [0.0, 1.0, 1.0, 2.0])
     assert np.allclose(out["menu_id_te_std"], [0.0, 0.0, 0.0, np.sqrt(2 / 3)])
+    assert np.allclose(out["store_menu_id_te_mean"], [0.0, 1.0, 1.5, 2.0])
+    assert np.allclose(
+        out["store_menu_id_te_std"], [0.0, 0.0, 0.5, np.sqrt(2 / 3)]
+    )
 
     # Mapping contains per-category and default statistics
     assert np.isclose(mapping["store_id"]["1"]["mean"], 1.5)
     assert np.isclose(mapping["store_id"]["2"]["std"], 0.5)
     assert np.isclose(mapping["menu_id"]["10"]["mean"], 2.0)
     assert np.isclose(mapping["menu_id"]["30"]["std"], 0.0)
+    assert np.isclose(mapping["store_menu_id"]["1_10"]["mean"], 1.0)
+    assert np.isclose(mapping["store_menu_id"]["2_30"]["std"], 0.0)
     assert np.isclose(
         mapping["store_id"]["__default__"]["mean"], mapping["__global__"]["mean"]
     )
     assert np.isclose(
         mapping["menu_id"]["__default__"]["std"], mapping["__global__"]["std"]
+    )
+    assert np.isclose(
+        mapping["store_menu_id"]["__default__"]["mean"], mapping["__global__"]["mean"]
     )
 
     # Reapply mapping to new data containing seen and unseen identifiers
@@ -54,29 +66,38 @@ def test_target_encoding_features_with_mapping_and_unseen():
             "d": pd.to_datetime(["2020-01-05", "2020-01-06", "2020-01-07"]),
             "store_id": [1, 3, 4],
             "menu_id": [20, 10, 40],
+            "store_menu_id": ["1_20", "3_10", "4_40"],
             "y": [0, 0, 0],
         }
     )
     out2, _ = create_target_encoding_features(
-        df2, ["store_id", "menu_id"], "y", "d", cfg, mapping
+        df2, ["store_id", "menu_id", "store_menu_id"], "y", "d", cfg, mapping
     )
 
     s_default = mapping["store_id"]["__default__"]
     m_default = mapping["menu_id"]["__default__"]
+    sm_default = mapping["store_menu_id"]["__default__"]
 
     # Row 0: both identifiers seen during fitting
     assert np.isclose(out2.loc[0, "store_id_te_mean"], mapping["store_id"]["1"]["mean"])
     assert np.isclose(out2.loc[0, "menu_id_te_mean"], mapping["menu_id"]["20"]["mean"])
+    assert np.isclose(
+        out2.loc[0, "store_menu_id_te_mean"], mapping["store_menu_id"]["1_20"]["mean"]
+    )
 
     # Row 1: unseen store_id but seen menu_id
     assert np.isclose(out2.loc[1, "store_id_te_mean"], s_default["mean"])
     assert np.isclose(out2.loc[1, "store_id_te_std"], s_default["std"])
     assert np.isclose(out2.loc[1, "menu_id_te_mean"], mapping["menu_id"]["10"]["mean"])
     assert np.isclose(out2.loc[1, "menu_id_te_std"], mapping["menu_id"]["10"]["std"])
+    assert np.isclose(out2.loc[1, "store_menu_id_te_mean"], sm_default["mean"])
+    assert np.isclose(out2.loc[1, "store_menu_id_te_std"], sm_default["std"])
 
     # Row 2: unseen identifiers receive default statistics
     assert np.isclose(out2.loc[2, "store_id_te_mean"], s_default["mean"])
     assert np.isclose(out2.loc[2, "store_id_te_std"], s_default["std"])
     assert np.isclose(out2.loc[2, "menu_id_te_mean"], m_default["mean"])
     assert np.isclose(out2.loc[2, "menu_id_te_std"], m_default["std"])
+    assert np.isclose(out2.loc[2, "store_menu_id_te_mean"], sm_default["mean"])
+    assert np.isclose(out2.loc[2, "store_menu_id_te_std"], sm_default["std"])
 


### PR DESCRIPTION
## Summary
- Derive `store_menu_id` from `store_id` and `menu_id` in `load_data`
- Include `store_menu_id` in configuration ID candidates
- Target encode `store_menu_id` and extend tests to cover combined IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c223dd769c832892e911f4ff96d629