### PR TITLE
Remove unused calendar features

### DIFF
--- a/g2_hurdle/fe/calendar.py
+++ b/g2_hurdle/fe/calendar.py
@@ -15,20 +15,19 @@ def create_calendar_features(df: pd.DataFrame, date_col: str) -> pd.DataFrame:
     d = out[date_col]
 
     # raw components
-    out["dow"] = d.dt.weekday
     out["week"] = d.dt.isocalendar().week.astype(int)
     out["month"] = d.dt.month
-    out["quarter"] = d.dt.quarter
     out["year"] = d.dt.year
 
     # cyclical (sin/cos) encodings
-    for col, period in [("dow", 7), ("week", 52), ("month", 12), ("quarter", 4)]:
+    for col, period in [("week", 52), ("month", 12)]:
         val = out[col].astype(float)
         out[f"{col}_sin"] = np.sin(2 * np.pi * val / period)
         out[f"{col}_cos"] = np.cos(2 * np.pi * val / period)
-        out[col] = out[col].astype("category")
+        if col != "month":
+            out[col] = out[col].astype("category")
 
-    out["is_month_start"] = d.dt.is_month_start.astype(int)
+    out.drop(columns=["month"], inplace=True)
+
     out["is_month_end"] = d.dt.is_month_end.astype(int)
-    out["is_weekend"] = d.dt.weekday.isin([5, 6]).astype(int)
     return out

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -35,7 +35,7 @@ def run_predict(cfg: dict):
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
         categories_map = features_meta.get("categories", {})
-        base_cats = ["dow", "week", "month", "quarter", "holiday_name"]
+        base_cats = ["week", "holiday_name"]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         train_cfg = art.get("config.json", {})
         if "features" in train_cfg:

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -74,7 +74,7 @@ def run_train(cfg: dict):
         ]
         X_all, feature_cols, categorical_cols = prepare_features(fe, drop_cols)
         # ensure calendar components are treated as categorical features
-        base_cats = [c for c in ["dow", "week", "month", "quarter", "holiday_name"] if c in X_all.columns]
+        base_cats = [c for c in ["week", "holiday_name"] if c in X_all.columns]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         if "holiday_name" in X_all.columns:
             assert pd.api.types.is_categorical_dtype(


### PR DESCRIPTION
## Summary
- Simplify calendar feature generation by dropping day-of-week, quarter, weekend and month-start fields
- Update training/prediction pipelines to exclude removed calendar columns
- Refresh sanity check script for new calendar feature set

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c22d2205208328b7dcfdd3ac85d8db