### PR TITLE
Refine lag and rolling feature defaults

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -17,7 +17,7 @@ data:
 
 features:
   fourier: { weekly_K: 3, yearly_K: 10 }
-  lags: [1,2,7,14,28,365]
+  lags: [1,7,28,365]
   rollings: [7,14,28]
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: true


### PR DESCRIPTION
## Summary
- drop lag_2 and lag_14, keeping default lags [1,7,28,365]
- compute roll_mean only for windows other than 7 or 14 and remove roll_min/roll_max features
- align recursion pipeline and base config with updated lag/rolling setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c22ea2304083288e22d9b5cc245682