### PR TITLE
Preserve identifier categoricals

### DIFF
--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -5,7 +5,7 @@ import pandas as pd
 def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categorical_cols=None, categories_map=None):
     X = fe_df.drop(columns=[c for c in drop_cols if c in fe_df.columns], errors="ignore").copy()
     X = X.replace([np.inf, -np.inf], np.nan)
-    for c in ["store_id", "menu_id"]:
+    for c in ["store_id", "menu_id", "store_menu_id"]:
         if c in X.columns:
             X[c] = X[c].astype("category")
     # Handle missing values separately for categorical and non-categorical columns

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -35,7 +35,13 @@ def run_predict(cfg: dict):
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
         categories_map = features_meta.get("categories", {})
-        base_cats = ["week", "holiday_name"]
+        base_cats = [
+            "week",
+            "holiday_name",
+            "store_id",
+            "menu_id",
+            "store_menu_id",
+        ]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         train_cfg = art.get("config.json", {})
         if "features" in train_cfg:
@@ -71,7 +77,11 @@ def run_predict(cfg: dict):
             schema_use["date"],
             schema_use["target"],
             "id",
-            *[c for c in schema_use["series"] if c not in ("store_id", "menu_id")],
+            *[
+                c
+                for c in schema_use["series"]
+                if c not in ("store_id", "menu_id", "store_menu_id")
+            ],
         ]
         X_test, _, _ = prepare_features(
             fe, drop_cols, feature_cols, categorical_cols, categories_map

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -225,7 +225,11 @@ def recursive_forecast_grouped(
     drop_cols = [
         date_col,
         target_col,
-        *[c for c in series_cols if c not in ("store_id", "menu_id")],
+        *[
+            c
+            for c in series_cols
+            if c not in ("store_id", "menu_id", "store_menu_id")
+        ],
     ]
     lags = cfg.get("features", {}).get("lags", [1, 7, 28, 365])
     lags = [l for l in lags if l not in (2, 14)]
@@ -251,10 +255,12 @@ def recursive_forecast_grouped(
             base_static = prepare_static_future_features(g, schema, cfg, H)
             static_cache[last_date] = base_static
         static_feats = base_static.copy()
-        for col in ("store_id", "menu_id"):
+        for col in ("store_id", "menu_id", "store_menu_id"):
             if col in g.columns:
                 val = str(g[col].iloc[0])
-                static_feats[col] = pd.Series([val] * len(static_feats), dtype="category")
+                static_feats[col] = pd.Series(
+                    [val] * len(static_feats), dtype="category"
+                )
                 if target_encoding_map and col in target_encoding_map:
                     stats = target_encoding_map[col].get(
                         val, target_encoding_map[col].get("__default__", {})

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -70,11 +70,24 @@ def run_train(cfg: dict):
             date_col,
             target_col,
             "id",
-            *[c for c in series_cols if c not in ("store_id", "menu_id")],
+            *[
+                c
+                for c in series_cols
+                if c not in ("store_id", "menu_id", "store_menu_id")
+            ],
+        ]
+        base_cats = [
+            c
+            for c in [
+                "week",
+                "holiday_name",
+                "store_id",
+                "menu_id",
+                "store_menu_id",
+            ]
+            if c in fe.columns
         ]
         X_all, feature_cols, categorical_cols = prepare_features(fe, drop_cols)
-        # ensure calendar components are treated as categorical features
-        base_cats = [c for c in ["week", "holiday_name"] if c in X_all.columns]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         if "holiday_name" in X_all.columns:
             assert pd.api.types.is_categorical_dtype(

--- a/tests/test_target_encoding_features.py
+++ b/tests/test_target_encoding_features.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from g2_hurdle.fe.embeddings import create_target_encoding_features
+from g2_hurdle.fe.preprocess import prepare_features
 
 
 def test_target_encoding_features_with_mapping_and_unseen():
@@ -100,4 +101,19 @@ def test_target_encoding_features_with_mapping_and_unseen():
     assert np.isclose(out2.loc[2, "menu_id_te_std"], m_default["std"])
     assert np.isclose(out2.loc[2, "store_menu_id_te_mean"], sm_default["mean"])
     assert np.isclose(out2.loc[2, "store_menu_id_te_std"], sm_default["std"])
+
+
+def test_prepare_features_marks_identifier_categoricals():
+    df = pd.DataFrame(
+        {
+            "d": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+            "store_id": [1, 2],
+            "menu_id": [10, 20],
+            "store_menu_id": ["1_10", "2_20"],
+            "y": [0, 1],
+        }
+    )
+    _, _, cat_cols = prepare_features(df, ["d", "y"])
+    for col in ["store_id", "menu_id", "store_menu_id"]:
+        assert col in cat_cols
 


### PR DESCRIPTION
## Summary
- Keep `store_id`, `menu_id`, and `store_menu_id` features during training and prediction
- Ensure recursion logic and preprocessing treat identifier columns as categorical
- Add tests confirming identifiers appear in categorical feature list

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c233add5c48328b7e0764cac2787c4