### PR TITLE
Add DTW demand clustering feature

### DIFF
--- a/dependency.py
+++ b/dependency.py
@@ -9,6 +9,9 @@ REQUIRED_PACKAGES = [
     "pyyaml",  # for reading YAML configuration files
     "scikit-learn",  # optional utilities for model evaluation
     "holidayskr",
+    "tslearn",
+    "cupy-cuda11x",
+    "cuml",
 ]
 
 def install_missing_packages(packages):

--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -22,6 +22,10 @@ features:
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: true
   intermittency: { enable: true }
+  dtw:
+    enable: true
+    n_clusters: 20
+    use_gpu: true  # fallback to CPU if no CUDA
 
 model:
   classifier:

--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -6,6 +6,7 @@ from .holiday import create_holiday_features
 from .lags_rolling import create_lags_and_rolling_features
 from .intermittency import create_intermittency_features
 from .preprocess import prepare_features
+from .dtw_cluster import compute_dtw_clusters
 
 
 def run_feature_engineering(
@@ -17,6 +18,27 @@ def run_feature_engineering(
     target_col = schema["target"]
     series_cols = schema["series"]
     out = df.copy()
+    extras = {}
+
+    dtw_cfg = cfg.get("features", {}).get("dtw", {})
+    if dtw_cfg.get("enable"):
+        if "demand_cluster" not in out.columns:
+            n_clusters = int(dtw_cfg.get("n_clusters", 20))
+            use_gpu = bool(dtw_cfg.get("use_gpu", True))
+            clusters = compute_dtw_clusters(out, schema, n_clusters, use_gpu)
+        else:
+            clusters = (
+                out[["store_menu_id", "demand_cluster"]]
+                .drop_duplicates()
+                .set_index("store_menu_id")
+                ["demand_cluster"]
+                .to_dict()
+            )
+        out["demand_cluster"] = (
+            out["store_menu_id"].map(clusters).astype("category")
+        )
+        extras["dtw_clusters"] = clusters
+
     out = create_calendar_features(out, date_col)
     if cfg.get("features", {}).get("use_holidays"):
         out = create_holiday_features(out, date_col)
@@ -29,4 +51,4 @@ def run_feature_engineering(
     out = create_lags_and_rolling_features(out, target_col, series_cols, cfg)
     if cfg.get("features", {}).get("intermittency", {}).get("enable", True):
         out = create_intermittency_features(out, target_col, series_cols)
-    return out, {}
+    return out, extras

--- a/g2_hurdle/fe/dtw_cluster.py
+++ b/g2_hurdle/fe/dtw_cluster.py
@@ -1,0 +1,84 @@
+import pandas as pd
+
+
+def compute_dtw_clusters(df: pd.DataFrame, schema: dict, n_clusters: int = 20, use_gpu: bool = True):
+    """Cluster demand series using Dynamic Time Warping distances.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input data containing at least date, target and ``store_menu_id`` columns.
+    schema : dict
+        Schema mapping with keys ``date`` and ``target``.
+    n_clusters : int, default 20
+        Number of clusters to form.
+    use_gpu : bool, default True
+        Whether to attempt GPU-accelerated computation. Falls back to CPU
+        implementations if GPU libraries are unavailable.
+
+    Returns
+    -------
+    dict
+        Mapping from ``store_menu_id`` to assigned cluster label.
+    """
+
+    date_col = schema["date"]
+    target_col = schema["target"]
+    if "store_menu_id" not in df.columns:
+        raise KeyError("compute_dtw_clusters requires 'store_menu_id' column")
+
+    # Pivot demand by store_menu_id -> time series rows
+    pivot = (
+        df.pivot_table(
+            index="store_menu_id",
+            columns=date_col,
+            values=target_col,
+            fill_value=0,
+        )
+        .sort_index()
+        .sort_index(axis=1)
+    )
+    series_ids = pivot.index.tolist()
+    data = pivot.values.astype("float32")
+
+    n_clusters = int(min(max(1, n_clusters), len(series_ids)))
+
+    distance_matrix = None
+    if use_gpu:
+        try:  # pragma: no cover - GPU path isn't exercised in tests
+            import cupy as cp
+            try:
+                from cudtw import distance_matrix as cudtw_distance_matrix
+
+                distance_matrix = cudtw_distance_matrix(cp.asarray(data))
+                distance_matrix = cp.asnumpy(distance_matrix)
+            except Exception:  # fall back to CPU DTW
+                distance_matrix = None
+        except Exception:
+            distance_matrix = None
+
+    if distance_matrix is None:
+        from tslearn.metrics import cdist_dtw
+
+        distance_matrix = cdist_dtw(data)
+
+    labels = None
+    if use_gpu:
+        try:  # pragma: no cover
+            from cuml.cluster import KMeans as cuKMeans
+
+            km = cuKMeans(n_clusters=n_clusters, random_state=0)
+            labels = km.fit_predict(distance_matrix)
+            labels = labels.get() if hasattr(labels, "get") else labels
+        except Exception:
+            labels = None
+
+    if labels is None:
+        from sklearn.cluster import KMeans
+
+        km = KMeans(n_clusters=n_clusters, random_state=0)
+        labels = km.fit_predict(distance_matrix)
+
+    labels = [int(x) for x in labels]
+    clusters = dict(zip(series_ids, labels))
+    return clusters

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -35,12 +35,14 @@ def run_predict(cfg: dict):
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
         categories_map = features_meta.get("categories", {})
+        dtw_clusters = art.get("dtw_clusters.json", {})
         base_cats = [
             "week",
             "holiday_name",
             "store_id",
             "menu_id",
             "store_menu_id",
+            "demand_cluster",
         ]
         categorical_cols = sorted(set(categorical_cols).union(base_cats))
         train_cfg = art.get("config.json", {})
@@ -62,6 +64,10 @@ def run_predict(cfg: dict):
         )
         # ensure id
         df["id"] = build_series_id(df, (schema or _schema)["series"])
+        if cfg.get("features", {}).get("dtw", {}).get("enable") and dtw_clusters:
+            df["demand_cluster"] = (
+                df["store_menu_id"].map(dtw_clusters).astype("category")
+            )
         # context length check
         min_ctx = int(cfg.get("data", {}).get("min_context_days", 28))
         # For each id, ensure at least 28 rows

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -254,7 +254,7 @@ def recursive_forecast_grouped(
             base_static = prepare_static_future_features(g, schema, cfg, H)
             static_cache[last_date] = base_static
         static_feats = base_static.copy()
-        for col in ("store_id", "menu_id", "store_menu_id"):
+        for col in ("store_id", "menu_id", "store_menu_id", "demand_cluster"):
             if col in g.columns:
                 val = str(g[col].iloc[0])
                 static_feats[col] = pd.Series(

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -65,7 +65,7 @@ def run_train(cfg: dict):
     seed = int(cfg.get("runtime", {}).get("seed", 42))
 
     with Timer("Feature engineering"):
-        fe, _ = run_feature_engineering(df, cfg, schema)
+        fe, extras = run_feature_engineering(df, cfg, schema)
         drop_cols = [
             date_col,
             target_col,
@@ -84,6 +84,7 @@ def run_train(cfg: dict):
                 "store_id",
                 "menu_id",
                 "store_menu_id",
+                "demand_cluster",
             ]
             if c in fe.columns
         ]
@@ -419,5 +420,7 @@ def run_train(cfg: dict):
             "categories": categories_map,
         },
     }
+    if extras.get("dtw_clusters") is not None:
+        artifacts["dtw_clusters.json"] = extras["dtw_clusters"]
     save_artifacts(artifacts, artifacts_dir)
     logger.info("Training complete.")

--- a/tests/test_dtw_cluster_feature.py
+++ b/tests/test_dtw_cluster_feature.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from g2_hurdle.fe import run_feature_engineering
+
+
+def test_dtw_cluster_feature():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=5).tolist() * 2,
+            "store_menu_id": ["A"] * 5 + ["B"] * 5,
+            "y": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+        }
+    )
+    cfg = {
+        "features": {
+            "dtw": {"enable": True, "n_clusters": 2, "use_gpu": False},
+            "lags": [],
+            "rollings": [],
+            "fourier": {"weekly_K": 0, "yearly_K": 0},
+            "intermittency": {"enable": False},
+            "use_holidays": False,
+        }
+    }
+    schema = {"date": "date", "target": "y", "series": ["store_menu_id"]}
+
+    out, extras = run_feature_engineering(df, cfg, schema)
+
+    assert "demand_cluster" in out.columns
+    assert pd.api.types.is_categorical_dtype(out["demand_cluster"])
+    assert set(extras["dtw_clusters"].keys()) == set(df["store_menu_id"].unique())


### PR DESCRIPTION
## Summary
- Implement compute_dtw_clusters to cluster store-menu demand series via DTW with optional GPU acceleration
- Integrate demand_cluster feature across training, prediction and recursive forecast pipelines, saving and loading cluster mappings
- Add DTW config block, dependencies, and corresponding tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2403afd1c8328afef12491922aae4