### PR TITLE
Align prediction IDs with store_menu_id

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -8,7 +8,6 @@ from ..utils.logging import get_logger
 from ..utils.timer import Timer
 from ..utils.io import load_artifacts, load_data
 from ..utils.keys import (
-    build_series_id,
     align_to_submission,
     ensure_wide_columns,
     normalize_series_name,
@@ -62,8 +61,8 @@ def run_predict(cfg: dict):
             f,
             {"data": {"date_col_candidates": [schema.get("date")], "target_col_candidates": [schema.get("target")], "id_col_candidates": schema.get("series", [])}} if schema else cfg,
         )
-        # ensure id
-        df["id"] = build_series_id(df, (schema or _schema)["series"])
+        # ensure id using store_menu_id only
+        df["id"] = normalize_series_name(df["store_menu_id"])
         if cfg.get("features", {}).get("dtw", {}).get("enable") and dtw_clusters:
             df["demand_cluster"] = (
                 df["store_menu_id"].map(dtw_clusters).astype("category")


### PR DESCRIPTION
## Summary
- Generate prediction IDs by normalizing `store_menu_id` instead of building from multiple series columns so they match submission menu names

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25503a0b083288d521862d336846e