### PR TITLE
Use provided series ids in recursion and prediction

### DIFF
--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -8,7 +8,6 @@ from ..utils.logging import get_logger
 from ..utils.timer import Timer
 from ..utils.io import load_artifacts, load_data
 from ..utils.keys import (
-    build_series_id,
     align_to_submission,
     ensure_wide_columns,
     normalize_series_name,
@@ -63,7 +62,7 @@ def run_predict(cfg: dict):
             {"data": {"date_col_candidates": [schema.get("date")], "target_col_candidates": [schema.get("target")], "id_col_candidates": schema.get("series", [])}} if schema else cfg,
         )
         # ensure id
-        df["id"] = build_series_id(df, (schema or _schema)["series"])
+        df["id"] = normalize_series_name(df["store_menu_id"])
         if cfg.get("features", {}).get("dtw", {}).get("enable") and dtw_clusters:
             df["demand_cluster"] = (
                 df["store_menu_id"].map(dtw_clusters).astype("category")

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -217,7 +217,13 @@ def recursive_forecast_grouped(
 
     # Ensure series id
     from ..utils.keys import build_series_id, ensure_wide_columns
-    id_series = build_series_id(context_df, series_cols)
+
+    # Use existing "id" column when provided for backward compatibility
+    if "id" in context_df.columns:
+        id_series = context_df["id"].astype(str)
+    else:
+        id_series = build_series_id(context_df, series_cols)
+
     context_df = context_df.copy()
     context_df["_series_id"] = id_series
 


### PR DESCRIPTION
## Summary
- Use existing `id` column in `recursive_forecast_grouped`, falling back to `build_series_id` only when absent
- Populate `id` in prediction pipeline from normalized `store_menu_id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c257e9a1dc8328b847776f3701d543