### PR TITLE
Ensure menu-level grouping and document demand_cluster feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,8 @@ data:
 
 If these keys are omitted, `resolve_schema` falls back to the corresponding
 `*_col_candidates` lists to infer column names.
+
+> **Note**
+> The optional `demand_cluster` column represents similarity-based clusters and
+> is used only as an additional categorical feature. The pipeline always groups
+> data by `store_menu_id`; `demand_cluster` never replaces this identifier.

--- a/g2_hurdle/fe/__init__.py
+++ b/g2_hurdle/fe/__init__.py
@@ -16,7 +16,7 @@ def run_feature_engineering(
 ):
     date_col = schema["date"]
     target_col = schema["target"]
-    series_cols = schema["series"]
+    series_cols = [c for c in schema.get("series", []) if c != "demand_cluster"]
     out = df.copy()
     extras = {}
 

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -30,6 +30,8 @@ def run_predict(cfg: dict):
         reg = art.get("regressor.pkl")
         thresh = float(art.get("threshold.json", {}).get("threshold", 0.5))
         schema = art.get("schema.json", None) or {}
+        if schema:
+            schema["series"] = ["store_menu_id"]
         features_meta = art.get("features.json", {})
         feature_cols = features_meta.get("feature_cols", [])
         categorical_cols = features_meta.get("categorical_cols", [])
@@ -61,6 +63,7 @@ def run_predict(cfg: dict):
             f,
             {"data": {"date_col_candidates": [schema.get("date")], "target_col_candidates": [schema.get("target")], "id_col_candidates": schema.get("series", [])}} if schema else cfg,
         )
+        _schema["series"] = ["store_menu_id"]
         # ensure id
         df["id"] = normalize_series_name(df["store_menu_id"])
         if cfg.get("features", {}).get("dtw", {}).get("enable") and dtw_clusters:
@@ -76,6 +79,8 @@ def run_predict(cfg: dict):
 
         # Optionally compute features to ensure column alignment
         schema_use = schema or _schema
+        schema_use["series"] = ["store_menu_id"]
+        df = df.sort_values(["store_menu_id", schema_use["date"]]).reset_index(drop=True)
         fe, _ = run_feature_engineering(df, cfg, schema_use)
         drop_cols = [
             schema_use["date"],

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -54,9 +54,10 @@ def run_train(cfg: dict):
 
     with Timer("Load data"):
         df, schema = load_data(train_csv, cfg)
+        schema["series"] = ["store_menu_id"]
         date_col = schema["date"]
         target_col = schema["target"]
-        series_cols = ["store_menu_id"]
+        series_cols = schema["series"]
         df = df.sort_values([*series_cols, date_col]).reset_index(drop=True)
         df["id"] = normalize_series_name(df["store_menu_id"])
 


### PR DESCRIPTION
## Summary
- Force schema series to `store_menu_id` for consistent menu-level grouping across train and predict pipelines
- Treat `demand_cluster` as a categorical feature only by filtering it from `schema['series']`
- Document that `demand_cluster` supplements `store_menu_id` and does not replace it

## Testing
- `python dependency.py` *(fails: cuml wheel build error)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25ebada608328adff9c92362c8f35