### PR TITLE
Include cudtw in dependency list

### DIFF
--- a/dependency.py
+++ b/dependency.py
@@ -12,6 +12,7 @@ REQUIRED_PACKAGES = [
     "tslearn",
     "cupy-cuda11x",
     "cuml",
+    "cudtw",
 ]
 
 def install_missing_packages(packages):


### PR DESCRIPTION
## Summary
- add `cudtw` to the list of required packages

## Testing
- `python dependency.py` *(fails: cuml requires installation from the rapidsai conda channel)*

------
https://chatgpt.com/codex/tasks/task_e_68c2625ed9488328a9ff1acd10706833