### PR TITLE
Ensure preprocessing retains missing category

### DIFF
--- a/g2_hurdle/fe/preprocess.py
+++ b/g2_hurdle/fe/preprocess.py
@@ -46,6 +46,9 @@ def prepare_features(fe_df: pd.DataFrame, drop_cols, feature_cols=None, categori
     if categories_map:
         for c, cats in categories_map.items():
             if c in X.columns:
+                cats = list(cats)
+                if "missing" not in cats:
+                    cats = cats + ["missing"]
                 X[c] = (
                     X[c]
                     .astype("category")

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from g2_hurdle.fe.preprocess import prepare_features
+
+
+def test_prepare_features_missing_category_map():
+    df = pd.DataFrame(
+        {
+            "store_id": pd.Series(["A", None, "B"], dtype="category"),
+            "obj_col": ["x", None, "y"],
+            "num_col": [1.0, 2.0, None],
+        }
+    )
+
+    X, feature_cols, categorical_cols = prepare_features(
+        df,
+        drop_cols=[],
+        categories_map={"store_id": ["A", "B"]},
+    )
+
+    assert pd.api.types.is_categorical_dtype(X["store_id"])
+    assert "missing" in X["store_id"].cat.categories
+    assert X.loc[1, "store_id"] == "missing"
+    assert X.select_dtypes(include="object").empty


### PR DESCRIPTION
## Summary
- Append "missing" to category lists before setting categories in `prepare_features`
- Add regression test ensuring no object dtypes remain when `categories_map` omits "missing"

## Testing
- `pre-commit run --files g2_hurdle/fe/preprocess.py tests/test_preprocess.py` (fails: command not found)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c26eac649883288c242ac0f986e6e0