### PR TITLE
Specify observed flag in DTW cluster pivot_table

### DIFF
--- a/g2_hurdle/fe/dtw_cluster.py
+++ b/g2_hurdle/fe/dtw_cluster.py
@@ -45,6 +45,7 @@ def compute_dtw_clusters(
             columns=date_col,
             values=target_col,
             fill_value=0,
+            observed=False,
         )
         .sort_index()
         .sort_index(axis=1)


### PR DESCRIPTION
## Summary
- Explicitly set `observed=False` in `compute_dtw_clusters` pivot table to avoid dependence on pandas defaults
- Verified no other `pivot_table` calls rely on default `observed` behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2733108748328a748916ebb2120e8