### PR TITLE
Downgrade DTW GPU message and disable GPU by default

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -25,7 +25,7 @@ features:
   dtw:
     enable: true
     n_clusters: 20
-    use_gpu: true  # fallback to CPU if no CUDA
+    use_gpu: false
 
 model:
   classifier:

--- a/g2_hurdle/fe/dtw_cluster.py
+++ b/g2_hurdle/fe/dtw_cluster.py
@@ -56,7 +56,7 @@ def compute_dtw_clusters(
     n_clusters = int(min(max(1, n_clusters), len(series_ids)))
 
     if use_gpu:
-        logger.warning(
+        logger.debug(
             "GPU acceleration requested but not available; using CPU routines."
         )
 


### PR DESCRIPTION
## Summary
- use debug-level logging when DTW GPU acceleration isn't available
- disable DTW GPU usage by default in base config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2746f78008328a1f947962ba6680d