### PR TITLE
Add cluster rolling features and demand cluster target encoding

### DIFF
--- a/g2_hurdle/fe/embeddings.py
+++ b/g2_hurdle/fe/embeddings.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 def create_target_encoding_features(
@@ -136,3 +136,37 @@ def create_target_encoding_features(
     out = sorted_out.set_index("index").sort_index()
 
     return out, mapping
+
+
+def create_demand_cluster_embeddings(
+    df: pd.DataFrame,
+    target_col: str,
+    date_col: str,
+    cfg: dict,
+    mapping: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None,
+) -> Tuple[pd.DataFrame, Dict[str, Dict[str, Dict[str, float]]]]:
+    """Wrapper that applies target encoding to ``demand_cluster``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe with a ``demand_cluster`` column.
+    target_col : str
+        Name of the target column.
+    date_col : str
+        Name of the date column.
+    cfg : dict
+        Configuration dictionary forwarded to
+        :func:`create_target_encoding_features`.
+    mapping : dict, optional
+        Precomputed mapping for inference.
+    """
+
+    return create_target_encoding_features(
+        df,
+        ["demand_cluster"],
+        target_col,
+        date_col,
+        cfg,
+        mapping=mapping,
+    )

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -37,6 +37,7 @@ def run_predict(cfg: dict):
         categorical_cols = features_meta.get("categorical_cols", [])
         categories_map = features_meta.get("categories", {})
         dtw_clusters = art.get("dtw_clusters.json", {})
+        te_map = art.get("target_encoding.pkl", {})
         base_cats = [
             "week",
             "holiday_name",
@@ -81,7 +82,7 @@ def run_predict(cfg: dict):
         schema_use = schema or _schema
         schema_use["series"] = ["store_menu_id"]
         df = df.sort_values(["store_menu_id", schema_use["date"]]).reset_index(drop=True)
-        fe, _ = run_feature_engineering(df, cfg, schema_use)
+        fe, _ = run_feature_engineering(df, cfg, schema_use, mapping=te_map)
         drop_cols = [
             schema_use["date"],
             schema_use["target"],

--- a/tests/test_dtw_cluster_feature.py
+++ b/tests/test_dtw_cluster_feature.py
@@ -13,9 +13,9 @@ def test_dtw_cluster_feature():
     )
     cfg = {
         "features": {
-            "dtw": {"enable": True, "n_clusters": 2, "use_gpu": False},
+            "dtw": {"enable": True, "n_clusters": 1, "use_gpu": False},
             "lags": [],
-            "rollings": [],
+            "rollings": [7],
             "fourier": {"weekly_K": 0, "yearly_K": 0},
             "intermittency": {"enable": False},
             "use_holidays": False,
@@ -28,6 +28,18 @@ def test_dtw_cluster_feature():
     assert "demand_cluster" in out.columns
     assert pd.api.types.is_categorical_dtype(out["demand_cluster"])
     assert set(extras["dtw_clusters"].keys()) == set(df["store_menu_id"].unique())
+    assert "demand_vs_cluster_mean" in out.columns
+    exp = out.groupby(["demand_cluster", "date"], observed=False)["roll_mean_7"].transform("mean")
+    pd.testing.assert_series_equal(
+        out["demand_vs_cluster_mean"],
+        out["roll_mean_7"] - exp,
+        check_names=False,
+        check_dtype=False,
+    )
+    assert "demand_cluster_te_mean" in out.columns
+    assert "demand_cluster_te_std" in out.columns
+    assert "target_encoding" in extras
+    assert "demand_cluster" in extras["target_encoding"]
 
 
 def test_dtw_cluster_train_only():


### PR DESCRIPTION
## Summary
- compute demand vs cluster mean using rolling averages and expose mapping
- add demand cluster target encoding and integrate into feature pipeline
- persist target encoding mapping for inference and update train/predict pipelines

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c681e840832888bbc4db6793ec1b