### PR TITLE
Align DTW clustering defaults to four clusters

### DIFF
--- a/g2_hurdle/fe/dtw_cluster.py
+++ b/g2_hurdle/fe/dtw_cluster.py
@@ -23,7 +23,7 @@ def compute_dtw_clusters(
         Input data containing at least date, target and ``store_menu_id`` columns.
     schema : dict
         Schema mapping with keys ``date`` and ``target``.
-    n_clusters : int, default 20
+    n_clusters : int, default 4
         Number of clusters to form.
     use_gpu : bool, default False
         Retained for compatibility. If ``True``, a warning is logged and CPU

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -133,7 +133,7 @@ def run_train(cfg: dict):
         tr_inner, va_inner = _split_train_valid_by_tail_dates(df_tr, date_col, ratio_tail=28)
 
         dtw_cfg = cfg.get("features", {}).get("dtw", {})
-        n_clusters = int(dtw_cfg.get("n_clusters", 20))
+        n_clusters = int(dtw_cfg.get("n_clusters", 4))
         use_gpu = bool(dtw_cfg.get("use_gpu", True))
         clusters = compute_dtw_clusters(df_tr, schema, n_clusters, use_gpu)
 
@@ -352,7 +352,7 @@ def run_train(cfg: dict):
     clusters_all = None
     te_map = None
     if dtw_cfg.get("enable"):
-        n_clusters = int(dtw_cfg.get("n_clusters", 20))
+        n_clusters = int(dtw_cfg.get("n_clusters", 4))
         use_gpu = bool(dtw_cfg.get("use_gpu", True))
         clusters_all = compute_dtw_clusters(df, schema, n_clusters, use_gpu)
         fe_full = fe_base.copy()


### PR DESCRIPTION
## Summary
- Update DTW cluster feature docstring to reflect default of four clusters
- Default to four DTW clusters throughout training pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2e5ecbb708328a8c2b85b1b320b51