### PR TITLE
Disable DTW feature in base config

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -23,7 +23,7 @@ features:
   use_holidays: true
   intermittency: { enable: true }
   dtw:
-    enable: true
+    enable: false
     n_clusters: 2
     use_gpu: false
 


### PR DESCRIPTION
## Summary
- turn off DTW-based feature generation in the base configuration to skip demand clustering

## Testing
- `python - <<'PY'
import yaml
import pandas as pd
from g2_hurdle.fe import run_feature_engineering
with open('g2_hurdle/configs/base.yaml') as f:
    cfg = yaml.safe_load(f)
df = pd.DataFrame({'date': pd.date_range('2024-01-01', periods=5),'store_menu_id': ['A']*5,'y': [0,1,2,3,4]})
schema = {'date': 'date', 'target': 'y', 'series': ['store_menu_id']}
out, extras = run_feature_engineering(df, cfg, schema)
print('has_demand_cluster:', 'demand_cluster' in out.columns)
print('has_dtw_clusters:', 'dtw_clusters' in extras)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c35f5233ac83289559d29d587c4096