### PR TITLE
Include lag 2 and 14 features in forecasting pipeline

### DIFF
--- a/g2_hurdle/configs/base.yaml
+++ b/g2_hurdle/configs/base.yaml
@@ -17,7 +17,7 @@ data:
 
 features:
   fourier: { weekly_K: 3, yearly_K: 10 }
-  lags: [1,7,28,365]
+  lags: [1,2,7,14,28,365]
   rollings: [7,14,28]
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: true

--- a/g2_hurdle/fe/lags_rolling.py
+++ b/g2_hurdle/fe/lags_rolling.py
@@ -23,8 +23,6 @@ def create_lags_and_rolling_features(df: pd.DataFrame, target_col: str, series_c
     def _apply(group):
         s = group[target_col]
         for lag in lags:
-            if lag in (2, 14):
-                continue
             group[f"lag_{lag}"] = s.shift(lag)
         s_shift = s.shift(1)  # leakage guard
         for w in rolls:
@@ -94,8 +92,6 @@ def update_lags_and_rollings(ctx_tail: pd.DataFrame, new_y: float, cfg: dict) ->
 
     # compute lag features for the next step
     for lag in lags:
-        if lag in (2, 14):
-            continue
         if lag == 1:
             new_row[f"lag_{lag}"] = new_y
         else:

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -190,8 +190,6 @@ def _build_dynamic_row(
     """Construct a DataFrame row of dynamic features for feature ordering."""
     row = {}
     for lag in lags:
-        if lag in (2, 14):
-            continue
         row[f"lag_{lag}"] = float(history[-lag])
     for w in rolls:
         window = history[-w:]
@@ -251,7 +249,6 @@ def recursive_forecast_grouped(
         ],
     ]
     lags = cfg.get("features", {}).get("lags", [1, 7, 28, 365])
-    lags = [l for l in lags if l not in (2, 14)]
     rolls = cfg.get("features", {}).get("rollings", [7, 14, 28])
     tail_len = max(max(lags), max(rolls)) + 1
     use_intermittency = cfg.get("features", {}).get("intermittency", {}).get(

--- a/tests/test_lag_features.py
+++ b/tests/test_lag_features.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from g2_hurdle.fe.lags_rolling import (
+    create_lags_and_rolling_features,
+    update_lags_and_rollings,
+)
+
+
+def test_lag_2_and_14_creation_and_update():
+    df = pd.DataFrame({"y": list(range(1, 21))})
+    cfg = {"features": {"lags": [1, 2, 14], "rollings": []}}
+
+    ctx = create_lags_and_rolling_features(df, "y", [], cfg)
+    assert "lag_2" in ctx.columns
+    assert "lag_14" in ctx.columns
+
+    expected_lag2 = df["y"].shift(2).fillna(0).tolist()
+    expected_lag14 = df["y"].shift(14).fillna(0).tolist()
+    assert ctx["lag_2"].tolist() == expected_lag2
+    assert ctx["lag_14"].tolist() == expected_lag14
+
+    updated = update_lags_and_rollings(ctx, 21, cfg)
+    last = updated.iloc[-1]
+    assert last["lag_1"] == 21
+    assert last["lag_2"] == ctx.iloc[-1]["lag_1"]
+    assert last["lag_14"] == ctx["y"].iloc[-14]


### PR DESCRIPTION
## Summary
- compute lag_2 and lag_14 features when generating and updating lag/rolling statistics
- allow recursion pipeline to use configured lags without filtering out 2 or 14
- include lags 2 and 14 in the default configuration
- add unit test covering lag_2 and lag_14 creation and updates

## Testing
- `pytest tests/test_lag_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3662840d4832894b65574f84da5ce