### PR TITLE
Add weekend and day-of-week calendar features

### DIFF
--- a/g2_hurdle/fe/calendar.py
+++ b/g2_hurdle/fe/calendar.py
@@ -18,6 +18,9 @@ def create_calendar_features(df: pd.DataFrame, date_col: str) -> pd.DataFrame:
     out["week"] = d.dt.isocalendar().week.astype(int)
     out["month"] = d.dt.month
     out["year"] = d.dt.year
+    dow = d.dt.weekday
+    out["is_weekend"] = (dow >= 5).astype(int)
+    out["dow"] = dow.astype("category")
 
     # cyclical (sin/cos) encodings
     for col, period in [("week", 52), ("month", 12)]:

--- a/g2_hurdle/pipeline/predict.py
+++ b/g2_hurdle/pipeline/predict.py
@@ -40,6 +40,7 @@ def run_predict(cfg: dict):
         te_map = art.get("target_encoding.pkl", {})
         base_cats = [
             "week",
+            "dow",
             "holiday_name",
             "store_id",
             "menu_id",

--- a/g2_hurdle/pipeline/train.py
+++ b/g2_hurdle/pipeline/train.py
@@ -85,6 +85,7 @@ def run_train(cfg: dict):
             c
             for c in [
                 "week",
+                "dow",
                 "holiday_name",
                 "store_id",
                 "menu_id",

--- a/tests/test_calendar_features.py
+++ b/tests/test_calendar_features.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from g2_hurdle.fe.calendar import create_calendar_features
+
+
+def test_calendar_features_week_and_weekend():
+    """create_calendar_features should add week and weekend indicators."""
+
+    df = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=7, freq="D")})
+    result = create_calendar_features(df, "date")
+
+    assert "week" in result.columns
+    assert "is_weekend" in result.columns
+
+    # ISO calendar week 1 for all dates in the range
+    assert result["week"].tolist() == [1] * 7
+    # Weekend indicator: Saturday and Sunday only
+    assert result["is_weekend"].tolist() == [0, 0, 0, 0, 0, 1, 1]
+


### PR DESCRIPTION
## Summary
- add `dow` and `is_weekend` calendar features
- treat `dow` as categorical in training and prediction pipelines
- test calendar feature generation for weekend flags

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c37434df20832895c07a5008edb873