### PR TITLE
Ensure load_data outputs Asia/Seoul tz aware dates

### DIFF
--- a/g2_hurdle/utils/io.py
+++ b/g2_hurdle/utils/io.py
@@ -23,6 +23,12 @@ def load_data(path: str, cfg: dict):
     target_col = schema["target"]
     series_cols = schema["series"]
     df[date_col] = pd.to_datetime(df[date_col])
+    d = pd.to_datetime(df[date_col])
+    df[date_col] = (
+        d.dt.tz_localize("Asia/Seoul")
+        if d.dt.tz is None
+        else d.dt.tz_convert("Asia/Seoul")
+    )
     for c in series_cols:
         df[c] = df[c].astype("category")
     df = df.sort_values([*series_cols, date_col]).drop_duplicates([*series_cols, date_col])

--- a/tests/test_io_split_ids.py
+++ b/tests/test_io_split_ids.py
@@ -24,6 +24,7 @@ def test_load_data_splits_store_menu(tmp_path):
     assert out.loc[0, "store_id"] == "s1"
     assert out.loc[0, "menu_id"] == "m1"
     assert out.loc[0, "store_menu_id"] == "s1_m1"
+    assert out["영업일자"].dt.tz.zone == "Asia/Seoul"
     assert "영업장명_메뉴명" not in out.columns
     assert "store_id" in schema["series"]
     assert "menu_id" in schema["series"]


### PR DESCRIPTION
## Summary
- Localize or convert parsed date column to Asia/Seoul in load_data
- Test that loaded dates carry Asia/Seoul timezone

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3780fe5b48328b94b853e21cc1546