### PR TITLE
Normalize calendar date to Korea timezone

### DIFF
--- a/g2_hurdle/fe/calendar.py
+++ b/g2_hurdle/fe/calendar.py
@@ -12,7 +12,9 @@ def create_calendar_features(df: pd.DataFrame, date_col: str) -> pd.DataFrame:
     """
 
     out = df.copy()
-    d = out[date_col]
+    d = pd.to_datetime(out[date_col])
+    d = d.dt.tz_localize("Asia/Seoul") if d.dt.tz is None else d.dt.tz_convert("Asia/Seoul")
+    out[date_col] = d
 
     # raw components
     out["week"] = d.dt.isocalendar().week.astype(int)

--- a/tests/test_calendar_features.py
+++ b/tests/test_calendar_features.py
@@ -6,7 +6,9 @@ from g2_hurdle.fe.calendar import create_calendar_features
 def test_calendar_features_week_and_weekend():
     """create_calendar_features should add week and weekend indicators."""
 
-    df = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=7, freq="D")})
+    df = pd.DataFrame({
+        "date": pd.date_range("2024-01-01", periods=7, freq="D", tz="Asia/Seoul")
+    })
     result = create_calendar_features(df, "date")
 
     assert "week" in result.columns
@@ -16,4 +18,5 @@ def test_calendar_features_week_and_weekend():
     assert result["week"].tolist() == [1] * 7
     # Weekend indicator: Saturday and Sunday only
     assert result["is_weekend"].tolist() == [0, 0, 0, 0, 0, 1, 1]
+    assert str(result["date"].dt.tz) == "Asia/Seoul"
 


### PR DESCRIPTION
## Summary
- Normalize calendar feature generation to Asia/Seoul timezone
- Keep date column timezone-aware and compute weekend flags accordingly
- Update tests to supply Korea timezone dates and verify timezone preservation

## Testing
- `PYTHONPATH=. pytest tests/test_calendar_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c378fa1d6c83288c1c20fbede48b3e