### PR TITLE
Handle timezone-aware future dates

### DIFF
--- a/g2_hurdle/fe/static.py
+++ b/g2_hurdle/fe/static.py
@@ -33,7 +33,17 @@ def prepare_static_future_features(
     """
     date_col = schema["date"]
     last_date = df[date_col].max()
-    future_dates = pd.date_range(last_date + pd.Timedelta(days=1), periods=horizon, freq="D")
+    last_date = (
+        last_date.tz_localize("Asia/Seoul")
+        if last_date.tz is None
+        else last_date.tz_convert("Asia/Seoul")
+    )
+    future_dates = pd.date_range(
+        last_date + pd.Timedelta(days=1),
+        periods=horizon,
+        freq="D",
+        tz="Asia/Seoul",
+    )
     future_df = pd.DataFrame({date_col: future_dates})
     out = create_calendar_features(future_df, date_col)
     if cfg.get("features", {}).get("use_holidays"):

--- a/g2_hurdle/pipeline/recursion.py
+++ b/g2_hurdle/pipeline/recursion.py
@@ -265,6 +265,11 @@ def recursive_forecast_grouped(
     for sid, g in context_df.groupby("_series_id"):
         g = g.sort_values(date_col).copy()
         last_date = g[date_col].max()
+        last_date = (
+            last_date.tz_localize("Asia/Seoul")
+            if last_date.tz is None
+            else last_date.tz_convert("Asia/Seoul")
+        )
 
         base_static = static_cache.get(last_date)
         if base_static is None:

--- a/tests/test_static_future_features.py
+++ b/tests/test_static_future_features.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from g2_hurdle.fe.static import prepare_static_future_features
+
+
+def test_prepare_static_future_features_timezone():
+    df = pd.DataFrame({"ds": pd.date_range("2024-01-01", periods=5, freq="D")})
+    schema = {"date": "ds"}
+    cfg = {"features": {}}
+    out = prepare_static_future_features(df, schema, cfg, horizon=3)
+    assert str(out.index.tz) == "Asia/Seoul"
+    assert len(out) == 3


### PR DESCRIPTION
## Summary
- Localize last history date to Asia/Seoul and generate timezone-aware future dates
- Ensure recursive forecasting works with timezone-aware indices
- Test that `prepare_static_future_features` produces `Asia/Seoul` timestamps

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c379e8b6c88328b291dbfb90d00bc8