### PR TITLE
Ensure timezone-aware tests for Seoul localization

### DIFF
--- a/tests/test_calendar_features.py
+++ b/tests/test_calendar_features.py
@@ -1,4 +1,8 @@
 import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from g2_hurdle.fe.calendar import create_calendar_features
 
@@ -18,5 +22,17 @@ def test_calendar_features_week_and_weekend():
     assert result["week"].tolist() == [1] * 7
     # Weekend indicator: Saturday and Sunday only
     assert result["is_weekend"].tolist() == [0, 0, 0, 0, 0, 1, 1]
-    assert str(result["date"].dt.tz) == "Asia/Seoul"
+    assert result["date"].dt.tz.zone == "Asia/Seoul"
+
+
+def test_calendar_features_timezone_boundary():
+    """Weekend/week numbers should respect Asia/Seoul near UTC boundaries."""
+
+    utc_dates = pd.to_datetime(["2024-03-31 14:30", "2024-03-31 15:30"], utc=True)
+    df = pd.DataFrame({"date": utc_dates.tz_convert("Asia/Seoul")})
+    result = create_calendar_features(df, "date")
+
+    assert result["date"].dt.tz.zone == "Asia/Seoul"
+    assert result["is_weekend"].tolist() == [1, 0]
+    assert result["week"].tolist() == [13, 14]
 

--- a/tests/test_dtw_cluster_feature.py
+++ b/tests/test_dtw_cluster_feature.py
@@ -1,12 +1,18 @@
 import copy
 import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from g2_hurdle.fe import run_feature_engineering, compute_dtw_clusters
 
 
 def test_dtw_cluster_feature():
     df = pd.DataFrame(
         {
-            "date": pd.date_range("2024-01-01", periods=5).tolist() * 2,
+            "date": pd.date_range("2024-01-01", periods=5, tz="Asia/Seoul").tolist()
+            * 2,
             "store_menu_id": ["A"] * 5 + ["B"] * 5,
             "y": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
         }
@@ -24,6 +30,8 @@ def test_dtw_cluster_feature():
     schema = {"date": "date", "target": "y", "series": ["store_menu_id"]}
 
     out, extras = run_feature_engineering(df, cfg, schema)
+
+    assert out["date"].dt.tz.zone == "Asia/Seoul"
 
     assert "demand_cluster" in out.columns
     assert pd.api.types.is_categorical_dtype(out["demand_cluster"])
@@ -45,7 +53,8 @@ def test_dtw_cluster_feature():
 def test_dtw_cluster_train_only():
     df = pd.DataFrame(
         {
-            "date": pd.date_range("2024-01-01", periods=5).tolist() * 3,
+            "date": pd.date_range("2024-01-01", periods=5, tz="Asia/Seoul").tolist()
+            * 3,
             "store_menu_id": ["A"] * 5 + ["B"] * 5 + ["C"] * 5,
             "y": [0, 1, 0, 1, 0] * 3,
         }
@@ -65,6 +74,7 @@ def test_dtw_cluster_train_only():
     cfg_off = copy.deepcopy(cfg)
     cfg_off["features"]["dtw"]["enable"] = False
     fe_base, _ = run_feature_engineering(df, cfg_off, schema)
+    assert fe_base["date"].dt.tz.zone == "Asia/Seoul"
 
     df_tr = df[df["store_menu_id"].isin(["A", "B"])]
     clusters = compute_dtw_clusters(df_tr, schema, n_clusters=2, use_gpu=False)

--- a/tests/test_holiday_features.py
+++ b/tests/test_holiday_features.py
@@ -1,4 +1,9 @@
 import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from g2_hurdle.fe import run_feature_engineering
 
 
@@ -7,7 +12,8 @@ def test_holiday_features():
 
     df = pd.DataFrame(
         {
-            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"], utc=True)
+            .tz_convert("Asia/Seoul"),
             "y": [0, 0],
         }
     )
@@ -23,6 +29,8 @@ def test_holiday_features():
     schema = {"date": "date", "target": "y", "series": []}
 
     result, _ = run_feature_engineering(df, cfg, schema)
+
+    assert result["date"].dt.tz.zone == "Asia/Seoul"
 
     assert result["is_holiday"].tolist() == [1, 0]
     assert result["holiday_name"].astype(str).tolist() == ["신정", "None"]

--- a/tests/test_io_split_ids.py
+++ b/tests/test_io_split_ids.py
@@ -1,12 +1,21 @@
 import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from g2_hurdle.utils.io import load_data
 
 def test_load_data_splits_store_menu(tmp_path):
-    df = pd.DataFrame({
-        "영업일자": pd.to_datetime(["2024-01-01"]),
-        "매출수량": [1],
-        "영업장명_메뉴명": ["s1_m1"],
-    })
+    df = pd.DataFrame(
+        {
+            "영업일자": pd.to_datetime(["2024-01-01"], utc=True).tz_convert(
+                "Asia/Seoul"
+            ),
+            "매출수량": [1],
+            "영업장명_메뉴명": ["s1_m1"],
+        }
+    )
     csv_path = tmp_path / "data.csv"
     df.to_csv(csv_path, index=False)
     cfg = {

--- a/tests/test_rolling_min_max.py
+++ b/tests/test_rolling_min_max.py
@@ -37,9 +37,17 @@ def test_update_lags_and_rollings_updates_min_max():
 
 def test_build_dynamic_row_includes_min_max():
     history = np.array([1, 2, 3, 4, 5], dtype=np.float32)
-    row = _build_dynamic_row(history, None, [], [3], "date", pd.Timestamp("2020-01-01"))
+    row = _build_dynamic_row(
+        history,
+        None,
+        [],
+        [3],
+        "date",
+        pd.Timestamp("2020-01-01", tz="Asia/Seoul"),
+    )
     assert row["roll_min_3"].iat[0] == 3.0
     assert row["roll_max_3"].iat[0] == 5.0
+    assert row["date"].dt.tz.zone == "Asia/Seoul"
 
 
 def test_compute_dynamic_features_with_min_max():

--- a/tests/test_static_future_features.py
+++ b/tests/test_static_future_features.py
@@ -8,9 +8,11 @@ from g2_hurdle.fe.static import prepare_static_future_features
 
 
 def test_prepare_static_future_features_timezone():
-    df = pd.DataFrame({"ds": pd.date_range("2024-01-01", periods=5, freq="D")})
+    df = pd.DataFrame(
+        {"ds": pd.date_range("2024-01-01", periods=5, freq="D", tz="Asia/Seoul")}
+    )
     schema = {"date": "ds"}
     cfg = {"features": {}}
     out = prepare_static_future_features(df, schema, cfg, horizon=3)
-    assert str(out.index.tz) == "Asia/Seoul"
+    assert out.index.tz.zone == "Asia/Seoul"
     assert len(out) == 3


### PR DESCRIPTION
## Summary
- Use Asia/Seoul timezone in all date-based tests and verify localization
- Add regression test for weekend/week number handling near UTC boundaries
- Capture and assert timezone preservation across pipeline feature preparation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c37cdae8348328bdf64884df4bf0f3