### PR TITLE
Add DTW feature configuration for Korean profile

### DIFF
--- a/g2_hurdle/configs/korean.yaml
+++ b/g2_hurdle/configs/korean.yaml
@@ -23,6 +23,10 @@ features:
   # Whether to include holiday-based features. Set to false to disable.
   use_holidays: false
   intermittency: { enable: true }
+  dtw:
+    enable: true   # or false
+    n_clusters: 2
+    use_gpu: false
 
 model:
   classifier:


### PR DESCRIPTION
## Summary
- enable DTW clustering in Korean configuration with cluster count and GPU flag

## Testing
- `pytest -q`
- `python train.py` *(fails: lightgbm.basic.LightGBMError: No OpenCL device found)*

------
https://chatgpt.com/codex/tasks/task_e_68c38296a1bc8328af7028ddc875e0ac