### PR TITLE
Load base config before Korean overrides

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -2,9 +2,24 @@ import os
 import yaml
 from g2_hurdle.pipeline.predict import run_predict
 
+
+def deep_merge(base, overlay):
+    """Recursively merge two dictionaries."""
+    result = base.copy()
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(result.get(k), dict):
+            result[k] = deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
 def main():
+    with open("g2_hurdle/configs/base.yaml", "r") as f:
+        cfg_base = yaml.safe_load(f)
     with open("g2_hurdle/configs/korean.yaml", "r") as f:
-        cfg = yaml.safe_load(f)
+        cfg_korean = yaml.safe_load(f)
+    cfg = deep_merge(cfg_base, cfg_korean)
     cfg["paths"] = {
         "test_dir": "data/test",
         "sample_submission": "data/sample_submission.csv",

--- a/train.py
+++ b/train.py
@@ -2,9 +2,23 @@ import yaml
 from g2_hurdle.pipeline.train import run_train
 
 
+def deep_merge(base, overlay):
+    """Recursively merge two dictionaries."""
+    result = base.copy()
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(result.get(k), dict):
+            result[k] = deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
 def main():
+    with open("g2_hurdle/configs/base.yaml", "r") as f:
+        cfg_base = yaml.safe_load(f)
     with open("g2_hurdle/configs/korean.yaml", "r") as f:
-        cfg = yaml.safe_load(f)
+        cfg_korean = yaml.safe_load(f)
+    cfg = deep_merge(cfg_base, cfg_korean)
     cfg["paths"] = {"train_csv": "data/train.csv"}
     run_train(cfg)
 


### PR DESCRIPTION
## Summary
- Load base.yaml then overlay korean.yaml for both training and prediction
- Recursively merge nested config entries to preserve defaults like DTW settings

## Testing
- `python - <<'PY'
import yaml

# ... snippet ... but might not show in PR body? We can't run snippet? Wait instructions: For PR, we summarise tests run; in PR body we can note `pytest`. It's good to show tests result.

But commit summary is in final message. For PR body, we include tests with triple quotes. Maybe we can't run snippet in commit body. We'll just mention `pytest`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3848c9990832892b43e52f9490080